### PR TITLE
Fix radio styling, input sizing, and storage isolation

### DIFF
--- a/A1/A1.html
+++ b/A1/A1.html
@@ -79,7 +79,7 @@
       --dur-3: 320ms;
 
       /* Mobile-safe touch target */
-      --target-min: 44px;
+      --target-min: 38px;
 
       /* Container max */
       --container-max: 900px;
@@ -494,6 +494,13 @@
 
     .mc-option-label:hover { background-color: var(--hover-sage); }
 
+    .mc-option-label:has(input[type="radio"]:checked),
+    .mc-option-label.is-checked {
+      border-color: color-mix(in srgb, var(--primary-sage) 55%, transparent);
+      background-color: color-mix(in srgb, var(--primary-sage) 12%, #fff 88%);
+      box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary-sage) 45%, transparent 55%);
+    }
+
     .mc-option-item .option-control {
       flex-shrink: 0;
       inline-size: 24px;
@@ -506,9 +513,11 @@
       box-shadow: inset 0 1px 0 rgba(255,255,255,0.7);
     }
 
-    .mc-option-item input[type="radio"]:checked + .option-control { border-color: var(--primary-sage); }
+    .mc-option-label input[type="radio"]:checked + .option-control,
+    .mc-option-item input[type="radio"]:checked + label .option-control { border-color: var(--primary-sage); }
 
-    .mc-option-item input[type="radio"]:checked + .option-control::after {
+    .mc-option-label input[type="radio"]:checked + .option-control::after,
+    .mc-option-item input[type="radio"]:checked + label .option-control::after {
       content: '';
       position: absolute;
       inset: 50% auto auto 50%;
@@ -526,10 +535,17 @@
       font-size: 1rem;
     }
 
-    .mc-option-item input[type="radio"]:focus-visible + .option-control,
+    .mc-option-label input[type="radio"]:focus-visible + .option-control,
+    .mc-option-item input[type="radio"]:focus-visible + label .option-control {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
     .mc-option-label:focus-visible {
       outline: none;
       box-shadow: var(--ring);
+      border-color: color-mix(in srgb, var(--primary-sage) 55%, transparent);
+      background-color: color-mix(in srgb, var(--primary-sage) 12%, #fff 88%);
     }
 
     /* Slide controls */
@@ -714,8 +730,8 @@
       display: inline-flex;
       align-items: center;
       width: clamp(6.5ch, 24vw, 11ch);
-      min-height: 2.5rem;
-      padding: 0.4em 0.55em;
+      min-height: clamp(2rem, 4.8vw, 2.3rem);
+      padding: 0.35em 0.5em;
       margin: 0 0.25em 0.3em;
       font: inherit;
       line-height: 1.2;
@@ -825,50 +841,50 @@
                     <div class="mc-question" data-question-number="8">
                         <div class="mc-question-header"><p class="mc-question-text">8. Fatima lives with four other people.</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q8-true" name="q8" value="True"><label for="q8-true" class="mc-option-label"><span class="option-control"></span><span class="option-text">True</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q8-false" name="q8" value="False"><label for="q8-false" class="mc-option-label"><span class="option-control"></span><span class="option-text">False</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q8-true" name="q8" value="True"><span class="option-control"></span><span class="option-text">True</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q8-false" name="q8" value="False"><span class="option-control"></span><span class="option-text">False</span></label></div>
                         </div>
                     </div>
                     <div class="mc-question" data-question-number="9">
                         <div class="mc-question-header"><p class="mc-question-text">9. Her mother works at a hospital.</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q9-true" name="q9" value="True"><label for="q9-true" class="mc-option-label"><span class="option-control"></span><span class="option-text">True</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q9-false" name="q9" value="False"><label for="q9-false" class="mc-option-label"><span class="option-control"></span><span class="option-text">False</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q9-true" name="q9" value="True"><span class="option-control"></span><span class="option-text">True</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q9-false" name="q9" value="False"><span class="option-control"></span><span class="option-text">False</span></label></div>
                         </div>
                     </div>
                     <div class="mc-question" data-question-number="10">
                         <div class="mc-question-header"><p class="mc-question-text">10. Fatima takes the bus to school.</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q10-true" name="q10" value="True"><label for="q10-true" class="mc-option-label"><span class="option-control"></span><span class="option-text">True</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q10-false" name="q10" value="False"><label for="q10-false" class="mc-option-label"><span class="option-control"></span><span class="option-text">False</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q10-true" name="q10" value="True"><span class="option-control"></span><span class="option-text">True</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q10-false" name="q10" value="False"><span class="option-control"></span><span class="option-text">False</span></label></div>
                         </div>
                     </div>
                      <div class="mc-question" data-question-number="11">
                         <div class="mc-question-header"><p class="mc-question-text">11. She likes English because she enjoys learning new words.</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q11-true" name="q11" value="True"><label for="q11-true" class="mc-option-label"><span class="option-control"></span><span class="option-text">True</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q11-false" name="q11" value="False"><label for="q11-false" class="mc-option-label"><span class="option-control"></span><span class="option-text">False</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q11-true" name="q11" value="True"><span class="option-control"></span><span class="option-text">True</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q11-false" name="q11" value="False"><span class="option-control"></span><span class="option-text">False</span></label></div>
                         </div>
                     </div>
                     <div class="mc-question" data-question-number="12">
                         <div class="mc-question-header"><p class="mc-question-text">12. She thinks Maths is easy.</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q12-true" name="q12" value="True"><label for="q12-true" class="mc-option-label"><span class="option-control"></span><span class="option-text">True</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q12-false" name="q12" value="False"><label for="q12-false" class="mc-option-label"><span class="option-control"></span><span class="option-text">False</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q12-true" name="q12" value="True"><span class="option-control"></span><span class="option-text">True</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q12-false" name="q12" value="False"><span class="option-control"></span><span class="option-text">False</span></label></div>
                         </div>
                     </div>
                     <div class="mc-question" data-question-number="13">
                         <div class="mc-question-header"><p class="mc-question-text">13. She watches television before she does her homework.</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q13-true" name="q13" value="True"><label for="q13-true" class="mc-option-label"><span class="option-control"></span><span class="option-text">True</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q13-false" name="q13" value="False"><label for="q13-false" class="mc-option-label"><span class="option-control"></span><span class="option-text">False</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q13-true" name="q13" value="True"><span class="option-control"></span><span class="option-text">True</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q13-false" name="q13" value="False"><span class="option-control"></span><span class="option-text">False</span></label></div>
                         </div>
                     </div>
                     <div class="mc-question" data-question-number="14">
                         <div class="mc-question-header"><p class="mc-question-text">14. Her family travels by train to see her grandmother.</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q14-true" name="q14" value="True"><label for="q14-true" class="mc-option-label"><span class="option-control"></span><span class="option-text">True</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q14-false" name="q14" value="False"><label for="q14-false" class="mc-option-label"><span class="option-control"></span><span class="option-text">False</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q14-true" name="q14" value="True"><span class="option-control"></span><span class="option-text">True</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q14-false" name="q14" value="False"><span class="option-control"></span><span class="option-text">False</span></label></div>
                         </div>
                     </div>
 
@@ -908,81 +924,81 @@
                     <div class="mc-question" data-question-number="21">
                         <div class="mc-question-header"><p class="mc-question-text">21. When does the family go to the city farm?</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q21-a" name="q21" value="A"><label for="q21-a" class="mc-option-label"><span class="option-control"></span><span class="option-text">A. Every day</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q21-b" name="q21" value="B"><label for="q21-b" class="mc-option-label"><span class="option-control"></span><span class="option-text">B. Every Saturday</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q21-c" name="q21" value="C"><label for="q21-c" class="mc-option-label"><span class="option-control"></span><span class="option-text">C. Every Sunday</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q21-a" name="q21" value="A"><span class="option-control"></span><span class="option-text">A. Every day</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q21-b" name="q21" value="B"><span class="option-control"></span><span class="option-text">B. Every Saturday</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q21-c" name="q21" value="C"><span class="option-control"></span><span class="option-text">C. Every Sunday</span></label></div>
                         </div>
                     </div>
                     <div class="mc-question" data-question-number="22">
                         <div class="mc-question-header"><p class="mc-question-text">22. The text says the farm is...</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q22-a" name="q22" value="A"><label for="q22-a" class="mc-option-label"><span class="option-control"></span><span class="option-text">A. far from their home.</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q22-b" name="q22" value="B"><label for="q22-b" class="mc-option-label"><span class="option-control"></span><span class="option-text">B. not very big.</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q22-c" name="q22" value="C"><label for="q22-c" class="mc-option-label"><span class="option-control"></span><span class="option-text">C. very noisy.</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q22-a" name="q22" value="A"><span class="option-control"></span><span class="option-text">A. far from their home.</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q22-b" name="q22" value="B"><span class="option-control"></span><span class="option-text">B. not very big.</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q22-c" name="q22" value="C"><span class="option-control"></span><span class="option-text">C. very noisy.</span></label></div>
                         </div>
                     </div>
                     <div class="mc-question" data-question-number="23">
                         <div class="mc-question-header"><p class="mc-question-text">23. The writer thinks the lambs are...</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q23-a" name="q23" value="A"><label for="q23-a" class="mc-option-label"><span class="option-control"></span><span class="option-text">A. very small.</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q23-b" name="q23" value="B"><label for="q23-b" class="mc-option-label"><span class="option-control"></span><span class="option-text">B. very cute.</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q23-c" name="q23" value="C"><label for="q23-c" class="mc-option-label"><span class="option-control"></span><span class="option-text">C. very white.</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q23-a" name="q23" value="A"><span class="option-control"></span><span class="option-text">A. very small.</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q23-b" name="q23" value="B"><span class="option-control"></span><span class="option-text">B. very cute.</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q23-c" name="q23" value="C"><span class="option-control"></span><span class="option-text">C. very white.</span></label></div>
                         </div>
                     </div>
                     <div class="mc-question" data-question-number="24">
                         <div class="mc-question-header"><p class="mc-question-text">24. Who in the family likes the chickens?</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q24-a" name="q24" value="A"><label for="q24-a" class="mc-option-label"><span class="option-control"></span><span class="option-text">A. The writer</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q24-b" name="q24" value="B"><label for="q24-b" class="mc-option-label"><span class="option-control"></span><span class="option-text">B. The mother</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q24-c" name="q24" value="C"><label for="q24-c" class="mc-option-label"><span class="option-control"></span><span class="option-text">C. The father</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q24-a" name="q24" value="A"><span class="option-control"></span><span class="option-text">A. The writer</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q24-b" name="q24" value="B"><span class="option-control"></span><span class="option-text">B. The mother</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q24-c" name="q24" value="C"><span class="option-control"></span><span class="option-text">C. The father</span></label></div>
                         </div>
                     </div>
                     <div class="mc-question" data-question-number="25">
                         <div class="mc-question-header"><p class="mc-question-text">25. Where can they see the eggs?</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q25-a" name="q25" value="A"><label for="q25-a" class="mc-option-label"><span class="option-control"></span><span class="option-text">A. In the grass</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q25-b" name="q25" value="B"><label for="q25-b" class="mc-option-label"><span class="option-control"></span><span class="option-text">B. In a basket</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q25-c" name="q25" value="C"><label for="q25-c" class="mc-option-label"><span class="option-control"></span><span class="option-text">C. In the garden</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q25-a" name="q25" value="A"><span class="option-control"></span><span class="option-text">A. In the grass</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q25-b" name="q25" value="B"><span class="option-control"></span><span class="option-text">B. In a basket</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q25-c" name="q25" value="C"><span class="option-control"></span><span class="option-text">C. In the garden</span></label></div>
                         </div>
                     </div>
                     <div class="mc-question" data-question-number="26">
                         <div class="mc-question-header"><p class="mc-question-text">26. What does the mother like at the farm?</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q26-a" name="q26" value="A"><label for="q26-a" class="mc-option-label"><span class="option-control"></span><span class="option-text">A. The sheep</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q26-b" name="q26" value="B"><label for="q26-b" class="mc-option-label"><span class="option-control"></span><span class="option-text">B. The eggs</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q26-c" name="q26" value="C"><label for="q26-c" class="mc-option-label"><span class="option-control"></span><span class="option-text">C. The flowers</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q26-a" name="q26" value="A"><span class="option-control"></span><span class="option-text">A. The sheep</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q26-b" name="q26" value="B"><span class="option-control"></span><span class="option-text">B. The eggs</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q26-c" name="q26" value="C"><span class="option-control"></span><span class="option-text">C. The flowers</span></label></div>
                         </div>
                     </div>
                     <div class="mc-question" data-question-number="27">
                         <div class="mc-question-header"><p class="mc-question-text">27. What time do they go home?</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q27-a" name="q27" value="A"><label for="q27-a" class="mc-option-label"><span class="option-control"></span><span class="option-text">A. In the morning</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q27-b" name="q27" value="B"><label for="q27-b" class="mc-option-label"><span class="option-control"></span><span class="option-text">B. At one o'clock</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q27-c" name="q27" value="C"><label for="q27-c" class="mc-option-label"><span class="option-control"></span><span class="option-text">C. In the evening</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q27-a" name="q27" value="A"><span class="option-control"></span><span class="option-text">A. In the morning</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q27-b" name="q27" value="B"><span class="option-control"></span><span class="option-text">B. At one o'clock</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q27-c" name="q27" value="C"><span class="option-control"></span><span class="option-text">C. In the evening</span></label></div>
                         </div>
                     </div>
                     <div class="mc-question" data-question-number="28">
                         <div class="mc-question-header"><p class="mc-question-text">28. The family has a __________ time at the farm.</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q28-a" name="q28" value="A"><label for="q28-a" class="mc-option-label"><span class="option-control"></span><span class="option-text">A. nice</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q28-b" name="q28" value="B"><label for="q28-b" class="mc-option-label"><span class="option-control"></span><span class="option-text">B. long</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q28-c" name="q28" value="C"><label for="q28-c" class="mc-option-label"><span class="option-control"></span><span class="option-text">C. quiet</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q28-a" name="q28" value="A"><span class="option-control"></span><span class="option-text">A. nice</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q28-b" name="q28" value="B"><span class="option-control"></span><span class="option-text">B. long</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q28-c" name="q28" value="C"><span class="option-control"></span><span class="option-text">C. quiet</span></label></div>
                         </div>
                     </div>
                     <div class="mc-question" data-question-number="29">
                         <div class="mc-question-header"><p class="mc-question-text">29. Who is sometimes in the garden?</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q29-a" name="q29" value="A"><label for="q29-a" class="mc-option-label"><span class="option-control"></span><span class="option-text">A. The father</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q29-b" name="q29" value="B"><label for="q29-b" class="mc-option-label"><span class="option-control"></span><span class="option-text">B. A worker</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q29-c" name="q29" value="C"><label for="q29-c" class="mc-option-label"><span class="option-control"></span><span class="option-text">C. The writer</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q29-a" name="q29" value="A"><span class="option-control"></span><span class="option-text">A. The father</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q29-b" name="q29" value="B"><span class="option-control"></span><span class="option-text">B. A worker</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q29-c" name="q29" value="C"><span class="option-control"></span><span class="option-text">C. The writer</span></label></div>
                         </div>
                     </div>
                     <div class="mc-question" data-question-number="30">
                         <div class="mc-question-header"><p class="mc-question-text">30. How does the writer feel after the visit?</p></div>
                         <div class="mc-options-container">
-                            <div class="mc-option-item"><input type="radio" id="q30-a" name="q30" value="A"><label for="q30-a" class="mc-option-label"><span class="option-control"></span><span class="option-text">A. Tired</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q30-b" name="q30" value="B"><label for="q30-b" class="mc-option-label"><span class="option-control"></span><span class="option-text">B. Sad</span></label></div>
-                            <div class="mc-option-item"><input type="radio" id="q30-c" name="q30" value="C"><label for="q30-c" class="mc-option-label"><span class="option-control"></span><span class="option-text">C. Happy</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q30-a" name="q30" value="A"><span class="option-control"></span><span class="option-text">A. Tired</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q30-b" name="q30" value="B"><span class="option-control"></span><span class="option-text">B. Sad</span></label></div>
+                            <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q30-c" name="q30" value="C"><span class="option-control"></span><span class="option-text">C. Happy</span></label></div>
                         </div>
                     </div>
 
@@ -1044,6 +1060,18 @@
     document.addEventListener('DOMContentLoaded', () => {
         // --- CONSTANTS ---
         const EXAM_LEVEL = 'A1';
+
+        const STORAGE_KEY = `examState-${EXAM_LEVEL}`;
+
+        const LEGACY_STORAGE_KEY = 'examState';
+
+        if (LEGACY_STORAGE_KEY !== STORAGE_KEY && localStorage.getItem(LEGACY_STORAGE_KEY)) {
+
+            localStorage.removeItem(LEGACY_STORAGE_KEY);
+
+        }
+
+        const supportsHasSelector = typeof CSS !== 'undefined' && CSS.supports && CSS.supports('selector(:has(*))');
         const GS_WEB_APP_URL = 'https://script.google.com/macros/s/AKfycbyuncyjolsXX1u9plOYDzujafMIROGIkOOjZsn2ko_lbhNbU1mAXZXa5iMHaEKReTPX/exec';
         const TOTAL_TIME = 3600; // 60 minutes in seconds
         const SUBMISSION_TIMEOUT_MS = 12000;
@@ -1083,11 +1111,34 @@
         let remainingTime = TOTAL_TIME;
         let currentPassageIndex = 0;
 
+        function styleRadioGroup(radioName) {
+            if (supportsHasSelector || !radioName) return;
+            const radios = document.querySelectorAll(`input[type="radio"][name="${radioName}"]`);
+            radios.forEach(radio => {
+                const label = radio.closest('.mc-option-label');
+                if (label) {
+                    label.classList.toggle('is-checked', radio.checked);
+                }
+            });
+        }
+
+        function refreshAllRadioStyles() {
+            if (supportsHasSelector) return;
+            const handledNames = new Set();
+            document.querySelectorAll('input[type="radio"]').forEach(radio => {
+                if (radio.name && !handledNames.has(radio.name)) {
+                    handledNames.add(radio.name);
+                    styleRadioGroup(radio.name);
+                }
+            });
+        }
+
         // --- INITIALIZATION ---
         function init() {
             currentLevelSpan.textContent = `Current Level: ${EXAM_LEVEL}`;
             loadState();
             addEventListeners();
+            refreshAllRadioStyles();
         }
 
         function addEventListeners() {
@@ -1129,10 +1180,10 @@
                 return;
             }
 
-            const savedState = JSON.parse(localStorage.getItem('examState'));
+            const savedState = JSON.parse(localStorage.getItem(STORAGE_KEY));
             if (savedState && savedState.studentID !== enteredID) {
                 // New student, reset state
-                localStorage.removeItem('examState');
+                localStorage.removeItem(STORAGE_KEY);
                 studentID = enteredID;
                 studentAnswers = {};
                 remainingTime = TOTAL_TIME;
@@ -1147,7 +1198,7 @@
 
         // --- STATE MANAGEMENT (LOCAL STORAGE) ---
         function loadState() {
-            const savedState = JSON.parse(localStorage.getItem('examState'));
+            const savedState = JSON.parse(localStorage.getItem(STORAGE_KEY));
             if (savedState) {
                 studentIdInput.value = savedState.studentID || '';
                 studentAnswers = savedState.answers || {};
@@ -1164,7 +1215,7 @@
                 answers: studentAnswers,
                 remainingTime: remainingTime
             };
-            localStorage.setItem('examState', JSON.stringify(state));
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
         }
 
         function populateAnswers() {
@@ -1173,12 +1224,16 @@
                 const radioInputs = document.querySelectorAll(`input[type="radio"][name="q${qNum}"]`);
                 if (radioInputs.length > 0) {
                     const inputToSelect = document.querySelector(`input[name="q${qNum}"][value="${answer}"]`);
-                    if (inputToSelect) inputToSelect.checked = true;
+                    if (inputToSelect) {
+                        inputToSelect.checked = true;
+                        styleRadioGroup(inputToSelect.name);
+                    }
                 } else {
                     const textOrSelectInput = document.querySelector(`[data-question-number="${qNum}"]:not(.mc-question)`);
                     if (textOrSelectInput) textOrSelectInput.value = answer;
                 }
             });
+            refreshAllRadioStyles();
         }
 
         // --- TEST FUNCTIONALITY ---
@@ -1213,11 +1268,14 @@
         
         function handleAnswerChange(event) {
             const target = event.target;
-            const questionNumber = target.name.replace('q', '') || target.dataset.questionNumber;
-            if (questionNumber) {
-                studentAnswers[questionNumber] = target.value;
-                saveState();
+            const questionNumber = target.name ? target.name.replace('q', '') : target.dataset.questionNumber;
+            if (!questionNumber) return;
+
+            studentAnswers[questionNumber] = target.value;
+            if (target.type === 'radio') {
+                styleRadioGroup(target.name);
             }
+            saveState();
         }
 
         // --- TIMER ---
@@ -1344,7 +1402,7 @@
                 if (result.result === 'success') {
                     submissionStatus.textContent = 'Successfully submitted!';
                     submissionStatus.style.color = '#2E7D32';
-                    localStorage.removeItem('examState');
+                    localStorage.removeItem(STORAGE_KEY);
                     submissionConfirmed = true;
                     return;
                 }

--- a/A2-plus/A2-plus.html
+++ b/A2-plus/A2-plus.html
@@ -79,7 +79,7 @@
       --dur-3: 320ms;
 
       /* Mobile-safe touch target */
-      --target-min: 44px;
+      --target-min: 38px;
 
       /* Container max */
       --container-max: 900px;
@@ -494,6 +494,13 @@
 
     .mc-option-label:hover { background-color: var(--hover-sage); }
 
+    .mc-option-label:has(input[type="radio"]:checked),
+    .mc-option-label.is-checked {
+      border-color: color-mix(in srgb, var(--primary-sage) 55%, transparent);
+      background-color: color-mix(in srgb, var(--primary-sage) 12%, #fff 88%);
+      box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary-sage) 45%, transparent 55%);
+    }
+
     .mc-option-item .option-control {
       flex-shrink: 0;
       inline-size: 24px;
@@ -506,9 +513,11 @@
       box-shadow: inset 0 1px 0 rgba(255,255,255,0.7);
     }
 
-    .mc-option-item input[type="radio"]:checked + .option-control { border-color: var(--primary-sage); }
+    .mc-option-label input[type="radio"]:checked + .option-control,
+    .mc-option-item input[type="radio"]:checked + label .option-control { border-color: var(--primary-sage); }
 
-    .mc-option-item input[type="radio"]:checked + .option-control::after {
+    .mc-option-label input[type="radio"]:checked + .option-control::after,
+    .mc-option-item input[type="radio"]:checked + label .option-control::after {
       content: '';
       position: absolute;
       inset: 50% auto auto 50%;
@@ -526,10 +535,17 @@
       font-size: 1rem;
     }
 
-    .mc-option-item input[type="radio"]:focus-visible + .option-control,
+    .mc-option-label input[type="radio"]:focus-visible + .option-control,
+    .mc-option-item input[type="radio"]:focus-visible + label .option-control {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
     .mc-option-label:focus-visible {
       outline: none;
       box-shadow: var(--ring);
+      border-color: color-mix(in srgb, var(--primary-sage) 55%, transparent);
+      background-color: color-mix(in srgb, var(--primary-sage) 12%, #fff 88%);
     }
 
     /* Slide controls */
@@ -714,8 +730,8 @@
       display: inline-flex;
       align-items: center;
       width: clamp(6.5ch, 24vw, 11ch);
-      min-height: 2.5rem;
-      padding: 0.4em 0.55em;
+      min-height: clamp(2rem, 4.8vw, 2.3rem);
+      padding: 0.35em 0.5em;
       margin: 0 0.25em 0.3em;
       font: inherit;
       line-height: 1.2;
@@ -1056,6 +1072,18 @@
 
         // --- CONSTANTS ---
         const EXAM_LEVEL = 'A2+';
+
+        const STORAGE_KEY = `examState-${EXAM_LEVEL}`;
+
+        const LEGACY_STORAGE_KEY = 'examState';
+
+        if (LEGACY_STORAGE_KEY !== STORAGE_KEY && localStorage.getItem(LEGACY_STORAGE_KEY)) {
+
+            localStorage.removeItem(LEGACY_STORAGE_KEY);
+
+        }
+
+        const supportsHasSelector = typeof CSS !== 'undefined' && CSS.supports && CSS.supports('selector(:has(*))');
         const GS_WEB_APP_URL = 'https://script.google.com/macros/s/AKfycbyuncyjolsXX1u9plOYDzujafMIROGIkOOjZsn2ko_lbhNbU1mAXZXa5iMHaEKReTPX/exec';
         const TOTAL_TIME = 3600; // 60 minutes in seconds
         const SUBMISSION_TIMEOUT_MS = 12000;
@@ -1099,6 +1127,28 @@
         let timerInterval = null;
         let currentPassageIndex = 0;
 
+        const styleRadioGroup = (radioName) => {
+            if (supportsHasSelector || !radioName) return;
+            const radios = document.querySelectorAll(`input[type="radio"][name="${radioName}"]`);
+            radios.forEach(radio => {
+                const label = radio.closest('.mc-option-label');
+                if (label) {
+                    label.classList.toggle('is-checked', radio.checked);
+                }
+            });
+        };
+
+        const refreshAllRadioStyles = () => {
+            if (supportsHasSelector) return;
+            const seen = new Set();
+            document.querySelectorAll('input[type="radio"]').forEach(radio => {
+                if (radio.name && !seen.has(radio.name)) {
+                    seen.add(radio.name);
+                    styleRadioGroup(radio.name);
+                }
+            });
+        };
+
         // --- FUNCTIONS ---
 
         const showScreen = (screenName) => {
@@ -1137,7 +1187,7 @@
                     answers,
                     remainingTime,
                 };
-                localStorage.setItem('examState', JSON.stringify(state));
+                localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
             } catch (e) {
                 console.error("Could not save state to localStorage:", e);
             }
@@ -1145,7 +1195,7 @@
 
         const loadState = () => {
             try {
-                const savedState = localStorage.getItem('examState');
+                const savedState = localStorage.getItem(STORAGE_KEY);
                 if (savedState) {
                     const state = JSON.parse(savedState);
                     studentIdInput.value = state.studentID || '';
@@ -1156,7 +1206,7 @@
                 }
             } catch (e) {
                 console.error("Could not load state from localStorage:", e);
-                localStorage.removeItem('examState');
+                localStorage.removeItem(STORAGE_KEY);
             }
         };
 
@@ -1170,12 +1220,16 @@
                     const firstInput = inputs[0];
                     if (firstInput.type === 'radio') {
                         const matchingRadio = document.querySelector(`input[name="q${qNum}"][value="${answer}"]`);
-                        if (matchingRadio) matchingRadio.checked = true;
+                        if (matchingRadio) {
+                            matchingRadio.checked = true;
+                            styleRadioGroup(matchingRadio.name);
+                        }
                     } else {
                         firstInput.value = answer;
                     }
                 }
             });
+            refreshAllRadioStyles();
         };
         
         const showPassage = (index) => {
@@ -1195,6 +1249,7 @@
             if (firstFocusable) {
                 firstFocusable.focus();
             }
+            refreshAllRadioStyles();
         };
 
         const handleAnswerChange = (event) => {
@@ -1203,6 +1258,9 @@
             if (questionContainer) {
                 const qNum = questionContainer.dataset.questionNumber;
                 answers[qNum] = target.value.trim();
+                if (target.type === 'radio') {
+                    styleRadioGroup(target.name);
+                }
                 saveState();
             }
         };
@@ -1353,7 +1411,7 @@
 
             studentID = enteredID;
             
-            const savedStateJSON = localStorage.getItem('examState');
+            const savedStateJSON = localStorage.getItem(STORAGE_KEY);
             if (savedStateJSON) {
                 const savedState = JSON.parse(savedStateJSON);
                 if (savedState.studentID === studentID) {
@@ -1395,8 +1453,9 @@
 
         downloadCsvBtn.addEventListener('click', downloadCSV);
         submitBtn.addEventListener('click', submitToGoogleSheet);
-        
+
         // Initial setup
+        refreshAllRadioStyles();
         loadState();
         showScreen('studentId');
 

--- a/A2/A2.html
+++ b/A2/A2.html
@@ -79,7 +79,7 @@
       --dur-3: 320ms;
 
       /* Mobile-safe touch target */
-      --target-min: 44px;
+      --target-min: 38px;
 
       /* Container max */
       --container-max: 900px;
@@ -493,6 +493,13 @@
 
     .mc-option-label:hover { background-color: var(--hover-sage); }
 
+    .mc-option-label:has(input[type="radio"]:checked),
+    .mc-option-label.is-checked {
+      border-color: color-mix(in srgb, var(--primary-sage) 55%, transparent);
+      background-color: color-mix(in srgb, var(--primary-sage) 12%, #fff 88%);
+      box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary-sage) 45%, transparent 55%);
+    }
+
     .mc-option-item .option-control {
       flex-shrink: 0;
       inline-size: 24px;
@@ -505,9 +512,11 @@
       box-shadow: inset 0 1px 0 rgba(255,255,255,0.7);
     }
 
-    .mc-option-item input[type="radio"]:checked + .option-control { border-color: var(--primary-sage); }
+    .mc-option-label input[type="radio"]:checked + .option-control,
+    .mc-option-item input[type="radio"]:checked + label .option-control { border-color: var(--primary-sage); }
 
-    .mc-option-item input[type="radio"]:checked + .option-control::after {
+    .mc-option-label input[type="radio"]:checked + .option-control::after,
+    .mc-option-item input[type="radio"]:checked + label .option-control::after {
       content: '';
       position: absolute;
       inset: 50% auto auto 50%;
@@ -525,10 +534,17 @@
       font-size: 1rem;
     }
 
-    .mc-option-item input[type="radio"]:focus-visible + .option-control,
+    .mc-option-label input[type="radio"]:focus-visible + .option-control,
+    .mc-option-item input[type="radio"]:focus-visible + label .option-control {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
     .mc-option-label:focus-visible {
       outline: none;
       box-shadow: var(--ring);
+      border-color: color-mix(in srgb, var(--primary-sage) 55%, transparent);
+      background-color: color-mix(in srgb, var(--primary-sage) 12%, #fff 88%);
     }
 
     /* Slide controls */
@@ -713,8 +729,8 @@
       display: inline-flex;
       align-items: center;
       width: clamp(6.5ch, 24vw, 11ch);
-      min-height: 2.5rem;
-      padding: 0.4em 0.55em;
+      min-height: clamp(2rem, 4.8vw, 2.3rem);
+      padding: 0.35em 0.5em;
       margin: 0 0.25em 0.3em;
       font: inherit;
       line-height: 1.2;
@@ -788,57 +804,57 @@
                         <div class="mc-question" data-question-number="1">
                             <div class="mc-question-header"><p class="mc-question-text">1. Chloe is writing the email to a family member.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q1_opt1" name="q1" value="True"><label for="q1_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q1_opt2" name="q1" value="False"><label for="q1_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q1_opt3" name="q1" value="Not Given"><label for="q1_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q1_opt1" name="q1" value="True"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q1_opt2" name="q1" value="False"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q1_opt3" name="q1" value="Not Given"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="2" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">2. The club meets in the morning.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q2_opt1" name="q2" value="True"><label for="q2_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q2_opt2" name="q2" value="False"><label for="q2_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q2_opt3" name="q2" value="Not Given"><label for="q2_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q2_opt1" name="q2" value="True"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q2_opt2" name="q2" value="False"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q2_opt3" name="q2" value="Not Given"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="3" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">3. Chloe has a new and expensive camera.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q3_opt1" name="q3" value="True"><label for="q3_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q3_opt2" name="q3" value="False"><label for="q3_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q3_opt3" name="q3" value="Not Given"><label for="q3_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q3_opt1" name="q3" value="True"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q3_opt2" name="q3" value="False"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q3_opt3" name="q3" value="Not Given"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="4" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">4. Chloe enjoyed taking photos in the city.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q4_opt1" name="q4" value="True"><label for="q4_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q4_opt2" name="q4" value="False"><label for="q4_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q4_opt3" name="q4" value="Not Given"><label for="q4_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q4_opt1" name="q4" value="True"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q4_opt2" name="q4" value="False"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q4_opt3" name="q4" value="Not Given"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="5" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">5. Last week, the club members took photos of animals.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q5_opt1" name="q5" value="True"><label for="q5_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q5_opt2" name="q5" value="False"><label for="q5_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q5_opt3" name="q5" value="Not Given"><label for="q5_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q5_opt1" name="q5" value="True"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q5_opt2" name="q5" value="False"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q5_opt3" name="q5" value="Not Given"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="6" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">6. Chloe does not like the other people in the club.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q6_opt1" name="q6" value="True"><label for="q6_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q6_opt2" name="q6" value="False"><label for="q6_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q6_opt3" name="q6" value="Not Given"><label for="q6_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q6_opt1" name="q6" value="True"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q6_opt2" name="q6" value="False"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q6_opt3" name="q6" value="Not Given"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
                             </div>
                         </div>
                          <div class="mc-question" data-question-number="7" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">7. Chloe thinks the club is the best part of her week.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q7_opt1" name="q7" value="True"><label for="q7_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q7_opt2" name="q7" value="False"><label for="q7_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q7_opt3" name="q7" value="Not Given"><label for="q7_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q7_opt1" name="q7" value="True"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q7_opt2" name="q7" value="False"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q7_opt3" name="q7" value="Not Given"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
                             </div>
                         </div>
 
@@ -871,57 +887,57 @@
                         <div class="mc-question" data-question-number="14">
                             <div class="mc-question-header"><p class="mc-question-text">14. Why is Marco looking for a new flatmate?</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q14_opt1" name="q14" value="A"><label for="q14_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">A. He wants to move to a new flat.</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q14_opt2" name="q14" value="B"><label for="q14_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">B. His flat is too big for one person.</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q14_opt3" name="q14" value="C"><label for="q14_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">C. His current flatmate is leaving for work reasons.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q14_opt1" name="q14" value="A"><span class="option-control"></span><span class="mc-option-text">A. He wants to move to a new flat.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q14_opt2" name="q14" value="B"><span class="option-control"></span><span class="mc-option-text">B. His flat is too big for one person.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q14_opt3" name="q14" value="C"><span class="option-control"></span><span class="mc-option-text">C. His current flatmate is leaving for work reasons.</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="15" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">15. The monthly rent of £500 includes...</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q15_opt1" name="q15" value="A"><label for="q15_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">A. all bills.</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q15_opt2" name="q15" value="B"><label for="q15_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">B. water and internet.</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q15_opt3" name="q15" value="C"><label for="q15_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">C. electricity and gas.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q15_opt1" name="q15" value="A"><span class="option-control"></span><span class="mc-option-text">A. all bills.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q15_opt2" name="q15" value="B"><span class="option-control"></span><span class="mc-option-text">B. water and internet.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q15_opt3" name="q15" value="C"><span class="option-control"></span><span class="mc-option-text">C. electricity and gas.</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="16" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">16. The available bedroom contains...</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q16_opt1" name="q16" value="A"><label for="q16_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">A. a bed, a desk, and a TV.</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q16_opt2" name="q16" value="B"><label for="q16_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">B. a desk, a wardrobe, and a bed.</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q16_opt3" name="q16" value="C"><label for="q16_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">C. a wardrobe, a chair, and a bed.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q16_opt1" name="q16" value="A"><span class="option-control"></span><span class="mc-option-text">A. a bed, a desk, and a TV.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q16_opt2" name="q16" value="B"><span class="option-control"></span><span class="mc-option-text">B. a desk, a wardrobe, and a bed.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q16_opt3" name="q16" value="C"><span class="option-control"></span><span class="mc-option-text">C. a wardrobe, a chair, and a bed.</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="17" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">17. What does Marco say about himself?</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q17_opt1" name="q17" value="A"><label for="q17_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">A. He goes to the gym often.</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q17_opt2" name="q17" value="B"><label for="q17_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">B. He works during the week.</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q17_opt3" name="q17" value="C"><label for="q17_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">C. He enjoys cooking.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q17_opt1" name="q17" value="A"><span class="option-control"></span><span class="mc-option-text">A. He goes to the gym often.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q17_opt2" name="q17" value="B"><span class="option-control"></span><span class="mc-option-text">B. He works during the week.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q17_opt3" name="q17" value="C"><span class="option-control"></span><span class="mc-option-text">C. He enjoys cooking.</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="18" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">18. Marco is looking for a flatmate who is...</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q18_opt1" name="q18" value="A"><label for="q18_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">A. tidy and doesn't smoke.</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q18_opt2" name="q18" value="B"><label for="q18_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">B. active and likes sports.</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q18_opt3" name="q18" value="C"><label for="q18_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">C. sociable and likes parties.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q18_opt1" name="q18" value="A"><span class="option-control"></span><span class="mc-option-text">A. tidy and doesn't smoke.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q18_opt2" name="q18" value="B"><span class="option-control"></span><span class="mc-option-text">B. active and likes sports.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q18_opt3" name="q18" value="C"><span class="option-control"></span><span class="mc-option-text">C. sociable and likes parties.</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="19" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">19. How long is the bus journey to the city centre?</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q19_opt1" name="q19" value="A"><label for="q19_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">A. Five minutes.</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q19_opt2" name="q19" value="B"><label for="q19_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">B. Fifteen minutes.</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q19_opt3" name="q19" value="C"><label for="q19_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">C. Twenty minutes.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q19_opt1" name="q19" value="A"><span class="option-control"></span><span class="mc-option-text">A. Five minutes.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q19_opt2" name="q19" value="B"><span class="option-control"></span><span class="mc-option-text">B. Fifteen minutes.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q19_opt3" name="q19" value="C"><span class="option-control"></span><span class="mc-option-text">C. Twenty minutes.</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="20" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">20. What must a person also pay when they move in?</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q20_opt1" name="q20" value="A"><label for="q20_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">A. A deposit.</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q20_opt2" name="q20" value="B"><label for="q20_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">B. The first gas bill.</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q20_opt3" name="q20" value="C"><label for="q20_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">C. An agency fee.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q20_opt1" name="q20" value="A"><span class="option-control"></span><span class="mc-option-text">A. A deposit.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q20_opt2" name="q20" value="B"><span class="option-control"></span><span class="mc-option-text">B. The first gas bill.</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q20_opt3" name="q20" value="C"><span class="option-control"></span><span class="mc-option-text">C. An agency fee.</span></label></div>
                             </div>
                         </div>
                         
@@ -952,57 +968,57 @@
                         <div class="mc-question" data-question-number="27">
                             <div class="mc-question-header"><p class="mc-question-text">27. The bicycle was invented by one person.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q27_opt1" name="q27" value="True"><label for="q27_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q27_opt2" name="q27" value="False"><label for="q27_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q27_opt3" name="q27" value="Not Given"><label for="q27_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q27_opt1" name="q27" value="True"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q27_opt2" name="q27" value="False"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q27_opt3" name="q27" value="Not Given"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="28" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">28. The first "running machine" had pedals.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q28_opt1" name="q28" value="True"><label for="q28_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q28_opt2" name="q28" value="False"><label for="q28_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q28_opt3" name="q28" value="Not Given"><label for="q28_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q28_opt1" name="q28" value="True"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q28_opt2" name="q28" value="False"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q28_opt3" name="q28" value="Not Given"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="29" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">29. The "boneshaker" was not comfortable to ride.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q29_opt1" name="q29" value="True"><label for="q29_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q29_opt2" name="q29" value="False"><label for="q29_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q29_opt3" name="q29" value="Not Given"><label for="q29_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q29_opt1" name="q29" value="True"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q29_opt2" name="q29" value="False"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q29_opt3" name="q29" value="Not Given"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="30" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">30. The "high-wheel" bicycle was slower than the "boneshaker".</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q30_opt1" name="q30" value="True"><label for="q30_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q30_opt2" name="q30" value="False"><label for="q30_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q30_opt3" name="q30" value="Not Given"><label for="q30_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q30_opt1" name="q30" value="True"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q30_opt2" name="q30" value="False"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q30_opt3" name="q30" value="Not Given"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="31" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">31. The "high-wheel" bicycle was not very safe.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q31_opt1" name="q31" value="True"><label for="q31_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q31_opt2" name="q31" value="False"><label for="q31_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q31_opt3" name="q31" value="Not Given"><label for="q31_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q31_opt1" name="q31" value="True"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q31_opt2" name="q31" value="False"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q31_opt3" name="q31" value="Not Given"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="32" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">32. The "safety bicycle" had two wheels that were different sizes.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q32_opt1" name="q32" value="True"><label for="q32_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q32_opt2" name="q32" value="False"><label for="q32_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q32_opt3" name="q32" value="Not Given"><label for="q32_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q32_opt1" name="q32" value="True"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q32_opt2" name="q32" value="False"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q32_opt3" name="q32" value="Not Given"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
                             </div>
                         </div>
                         <div class="mc-question" data-question-number="33" style="margin-top: var(--space-4);">
                             <div class="mc-question-header"><p class="mc-question-text">33. The "safety bicycle" first became popular in Germany.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" id="q33_opt1" name="q33" value="True"><label for="q33_opt1" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q33_opt2" name="q33" value="False"><label for="q33_opt2" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
-                                <div class="mc-option-item"><input type="radio" id="q33_opt3" name="q33" value="Not Given"><label for="q33_opt3" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q33_opt1" name="q33" value="True"><span class="option-control"></span><span class="mc-option-text">True</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q33_opt2" name="q33" value="False"><span class="option-control"></span><span class="mc-option-text">False</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" id="q33_opt3" name="q33" value="Not Given"><span class="option-control"></span><span class="mc-option-text">Not Given</span></label></div>
                             </div>
                         </div>
                         
@@ -1045,6 +1061,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- CONFIGURATION & CONSTANTS ---
     const EXAM_LEVEL = 'A2';
+
+    const STORAGE_KEY = `examState-${EXAM_LEVEL}`;
+
+    const LEGACY_STORAGE_KEY = 'examState';
+
+    if (LEGACY_STORAGE_KEY !== STORAGE_KEY && localStorage.getItem(LEGACY_STORAGE_KEY)) {
+
+        localStorage.removeItem(LEGACY_STORAGE_KEY);
+
+    }
+
+    const supportsHasSelector = typeof CSS !== 'undefined' && CSS.supports && CSS.supports('selector(:has(*))');
     const GS_WEB_APP_URL = 'https://script.google.com/macros/s/AKfycbyuncyjolsXX1u9plOYDzujafMIROGIkOOjZsn2ko_lbhNbU1mAXZXa5iMHaEKReTPX/exec';
     const TOTAL_TIME = 3600; // 60 minutes in seconds
     const SUBMISSION_TIMEOUT_MS = 12000;
@@ -1086,6 +1114,28 @@ document.addEventListener('DOMContentLoaded', () => {
     const progressBar = document.getElementById('progress-bar');
     const progressText = document.getElementById('progress-text');
 
+    const styleRadioGroup = (radioName) => {
+        if (supportsHasSelector || !radioName) return;
+        const radios = document.querySelectorAll(`input[type="radio"][name="${radioName}"]`);
+        radios.forEach(radio => {
+            const label = radio.closest('.mc-option-label');
+            if (label) {
+                label.classList.toggle('is-checked', radio.checked);
+            }
+        });
+    };
+
+    const refreshAllRadioStyles = () => {
+        if (supportsHasSelector) return;
+        const seen = new Set();
+        document.querySelectorAll('input[type="radio"]').forEach(radio => {
+            if (radio.name && !seen.has(radio.name)) {
+                seen.add(radio.name);
+                styleRadioGroup(radio.name);
+            }
+        });
+    };
+
     // --- FUNCTIONS ---
 
     /**
@@ -1109,7 +1159,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 answers: studentAnswers,
                 remainingTime: remainingTime,
             };
-            localStorage.setItem('examState', JSON.stringify(state));
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
         } catch (error) {
             console.error("Could not save state to localStorage:", error);
         }
@@ -1120,7 +1170,7 @@ document.addEventListener('DOMContentLoaded', () => {
      */
     const loadState = () => {
         try {
-            const savedState = localStorage.getItem('examState');
+            const savedState = localStorage.getItem(STORAGE_KEY);
             if (savedState) {
                 const state = JSON.parse(savedState);
                 studentIdInput.value = state.studentID || '';
@@ -1147,6 +1197,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const inputToSelect = Array.from(radioInputs).find(input => input.value === answer);
                 if (inputToSelect) {
                     inputToSelect.checked = true;
+                    styleRadioGroup(inputToSelect.name);
                 }
             } else {
                 const textInput = document.querySelector(`input[type="text"][data-question-number="${qNum}"], input[type="text"]#q${qNum}`);
@@ -1156,6 +1207,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
         updateTimerDisplay();
+        refreshAllRadioStyles();
     };
 
 
@@ -1217,6 +1269,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (targetHeading) {
             targetHeading.focus();
         }
+        refreshAllRadioStyles();
     };
     
     /**
@@ -1255,6 +1308,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (qNum) {
             studentAnswers[qNum] = input.value.trim();
+            if (input.type === 'radio') {
+                styleRadioGroup(input.name);
+            }
             saveState();
         }
     };
@@ -1426,7 +1482,7 @@ document.addEventListener('DOMContentLoaded', () => {
         studentID = studentIdInput.value.trim();
         if (!studentID) return;
 
-        const savedStateJSON = localStorage.getItem('examState');
+        const savedStateJSON = localStorage.getItem(STORAGE_KEY);
         if (savedStateJSON) {
             const savedState = JSON.parse(savedStateJSON);
             if (savedState.studentID === studentID) {
@@ -1465,6 +1521,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 input.addEventListener('keyup', handleAnswerChange);
             }
         });
+        refreshAllRadioStyles();
     };
 
     init();

--- a/B1/B1.html
+++ b/B1/B1.html
@@ -79,7 +79,7 @@
       --dur-3: 320ms;
 
       /* Mobile-safe touch target */
-      --target-min: 44px;
+      --target-min: 38px;
 
       /* Container max */
       --container-max: 900px;
@@ -494,6 +494,13 @@
 
     .mc-option-label:hover { background-color: var(--hover-sage); }
 
+    .mc-option-label:has(input[type="radio"]:checked),
+    .mc-option-label.is-checked {
+      border-color: color-mix(in srgb, var(--primary-sage) 55%, transparent);
+      background-color: color-mix(in srgb, var(--primary-sage) 12%, #fff 88%);
+      box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary-sage) 45%, transparent 55%);
+    }
+
     .mc-option-item .option-control {
       flex-shrink: 0;
       inline-size: 24px;
@@ -506,9 +513,11 @@
       box-shadow: inset 0 1px 0 rgba(255,255,255,0.7);
     }
 
-    .mc-option-item input[type="radio"]:checked + .option-control { border-color: var(--primary-sage); }
+    .mc-option-label input[type="radio"]:checked + .option-control,
+    .mc-option-item input[type="radio"]:checked + label .option-control { border-color: var(--primary-sage); }
 
-    .mc-option-item input[type="radio"]:checked + .option-control::after {
+    .mc-option-label input[type="radio"]:checked + .option-control::after,
+    .mc-option-item input[type="radio"]:checked + label .option-control::after {
       content: '';
       position: absolute;
       inset: 50% auto auto 50%;
@@ -526,10 +535,17 @@
       font-size: 1rem;
     }
 
-    .mc-option-item input[type="radio"]:focus-visible + .option-control,
+    .mc-option-label input[type="radio"]:focus-visible + .option-control,
+    .mc-option-item input[type="radio"]:focus-visible + label .option-control {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
     .mc-option-label:focus-visible {
       outline: none;
       box-shadow: var(--ring);
+      border-color: color-mix(in srgb, var(--primary-sage) 55%, transparent);
+      background-color: color-mix(in srgb, var(--primary-sage) 12%, #fff 88%);
     }
 
     /* Slide controls */
@@ -714,8 +730,8 @@
       display: inline-flex;
       align-items: center;
       width: clamp(6.5ch, 24vw, 11ch);
-      min-height: 2.5rem;
-      padding: 0.4em 0.55em;
+      min-height: clamp(2rem, 4.8vw, 2.3rem);
+      padding: 0.35em 0.5em;
       margin: 0 0.25em 0.3em;
       font: inherit;
       line-height: 1.2;
@@ -1082,6 +1098,18 @@
 document.addEventListener('DOMContentLoaded', () => {
     // --- CONFIGURATION ---
     const EXAM_LEVEL = 'B1';
+
+    const STORAGE_KEY = `examState-${EXAM_LEVEL}`;
+
+    const LEGACY_STORAGE_KEY = 'examState';
+
+    if (LEGACY_STORAGE_KEY !== STORAGE_KEY && localStorage.getItem(LEGACY_STORAGE_KEY)) {
+
+        localStorage.removeItem(LEGACY_STORAGE_KEY);
+
+    }
+
+    const supportsHasSelector = typeof CSS !== 'undefined' && CSS.supports && CSS.supports('selector(:has(*))');
     const GS_WEB_APP_URL = 'https://script.google.com/macros/s/AKfycbyuncyjolsXX1u9plOYDzujafMIROGIkOOjZsn2ko_lbhNbU1mAXZXa5iMHaEKReTPX/exec';
     const TOTAL_TIME = 3600; // 60 minutes in seconds
     const SUBMISSION_TIMEOUT_MS = 12000;
@@ -1103,6 +1131,28 @@ document.addEventListener('DOMContentLoaded', () => {
         currentPassageIndex: 0
     };
     let timerInterval = null;
+
+    function styleRadioGroup(radioName) {
+        if (supportsHasSelector || !radioName) return;
+        const radios = document.querySelectorAll(`input[type="radio"][name="${radioName}"]`);
+        radios.forEach(radio => {
+            const label = radio.closest('.mc-option-label');
+            if (label) {
+                label.classList.toggle('is-checked', radio.checked);
+            }
+        });
+    }
+
+    function refreshAllRadioStyles() {
+        if (supportsHasSelector) return;
+        const processed = new Set();
+        document.querySelectorAll('input[type="radio"]').forEach(radio => {
+            if (radio.name && !processed.has(radio.name)) {
+                processed.add(radio.name);
+                styleRadioGroup(radio.name);
+            }
+        });
+    }
 
     // --- DOM ELEMENTS ---
     const screens = {
@@ -1130,6 +1180,7 @@ document.addEventListener('DOMContentLoaded', () => {
         loadStateFromLocalStorage();
         setupEventListeners();
         currentLevelDisplay.textContent = `Current Level: ${EXAM_LEVEL}`;
+        refreshAllRadioStyles();
     }
 
     function setupEventListeners() {
@@ -1159,7 +1210,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- STATE MANAGEMENT (LOCAL STORAGE) ---
     function saveStateToLocalStorage() {
         try {
-            localStorage.setItem('examState', JSON.stringify(state));
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
         } catch (e) {
             console.error("Could not save state to localStorage:", e);
         }
@@ -1167,7 +1218,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function loadStateFromLocalStorage() {
         try {
-            const savedState = localStorage.getItem('examState');
+            const savedState = localStorage.getItem(STORAGE_KEY);
             if (savedState) {
                 const parsedState = JSON.parse(savedState);
                 // Pre-fill student ID from saved state
@@ -1178,12 +1229,12 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         } catch (e) {
             console.error("Could not load state from localStorage:", e);
-            localStorage.removeItem('examState');
+            localStorage.removeItem(STORAGE_KEY);
         }
     }
     
     function restoreSessionIfMatched(enteredID) {
-        const savedState = JSON.parse(localStorage.getItem('examState') || '{}');
+        const savedState = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
         if (savedState.studentID === enteredID) {
             state = { ...state, ...savedState };
             
@@ -1193,6 +1244,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const radioInputs = document.querySelectorAll(`input[name="q${qNum}"][value="${value}"]`);
                 if (radioInputs.length > 0) {
                     radioInputs[0].checked = true;
+                    styleRadioGroup(radioInputs[0].name);
                 } else {
                     const otherInput = document.querySelector(`[data-question-number="${qNum}"], input[name="q${qNum}"]`);
                     if (otherInput) {
@@ -1200,10 +1252,12 @@ document.addEventListener('DOMContentLoaded', () => {
                     }
                 }
             });
+            refreshAllRadioStyles();
         } else {
              // New student ID, clear old answers and reset time
             state.answers = {};
             state.remainingTime = TOTAL_TIME;
+            refreshAllRadioStyles();
         }
     }
 
@@ -1271,9 +1325,10 @@ document.addEventListener('DOMContentLoaded', () => {
         
         const targetElement = passageSlides[index].querySelector('h3');
         if(targetElement) targetElement.focus();
-        
+
         updateProgress();
         updateNavButtons();
+        refreshAllRadioStyles();
     }
 
     function updateProgress() {
@@ -1309,6 +1364,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (qNum) {
             state.answers[qNum] = input.value;
+            if (input.type === 'radio') {
+                styleRadioGroup(input.name);
+            }
             saveStateToLocalStorage();
         }
     }

--- a/B2/B2.html
+++ b/B2/B2.html
@@ -79,7 +79,7 @@
       --dur-3: 320ms;
 
       /* Mobile-safe touch target */
-      --target-min: 44px;
+      --target-min: 38px;
 
       /* Container max */
       --container-max: 900px;
@@ -502,6 +502,13 @@
 
     .mc-option-label:hover { background-color: var(--hover-sage); }
 
+    .mc-option-label:has(input[type="radio"]:checked),
+    .mc-option-label.is-checked {
+      border-color: color-mix(in srgb, var(--primary-sage) 55%, transparent);
+      background-color: color-mix(in srgb, var(--primary-sage) 12%, #fff 88%);
+      box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary-sage) 45%, transparent 55%);
+    }
+
     .mc-option-item .option-control {
       flex-shrink: 0;
       inline-size: 24px;
@@ -514,9 +521,11 @@
       box-shadow: inset 0 1px 0 rgba(255,255,255,0.7);
     }
 
-    .mc-option-item input[type="radio"]:checked + .option-control { border-color: var(--primary-sage); }
+    .mc-option-label input[type="radio"]:checked + .option-control,
+    .mc-option-item input[type="radio"]:checked + label .option-control { border-color: var(--primary-sage); }
 
-    .mc-option-item input[type="radio"]:checked + .option-control::after {
+    .mc-option-label input[type="radio"]:checked + .option-control::after,
+    .mc-option-item input[type="radio"]:checked + label .option-control::after {
       content: '';
       position: absolute;
       inset: 50% auto auto 50%;
@@ -534,10 +543,17 @@
       font-size: 1rem;
     }
 
-    .mc-option-item input[type="radio"]:focus-visible + .option-control,
+    .mc-option-label input[type="radio"]:focus-visible + .option-control,
+    .mc-option-item input[type="radio"]:focus-visible + label .option-control {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
     .mc-option-label:focus-visible {
       outline: none;
       box-shadow: var(--ring);
+      border-color: color-mix(in srgb, var(--primary-sage) 55%, transparent);
+      background-color: color-mix(in srgb, var(--primary-sage) 12%, #fff 88%);
     }
 
     /* Slide controls */
@@ -722,8 +738,8 @@
       display: inline-flex;
       align-items: center;
       width: clamp(6.5ch, 24vw, 11ch);
-      min-height: 2.5rem;
-      padding: 0.4em 0.55em;
+      min-height: clamp(2rem, 4.8vw, 2.3rem);
+      padding: 0.35em 0.5em;
       margin: 0 0.25em 0.3em;
       font: inherit;
       line-height: 1.2;
@@ -799,54 +815,54 @@
                         <div class="mc-question" data-question-number="1">
                             <div class="mc-question-header"><p class="mc-question-text">1. Remote work is an entirely new concept developed in the 21st century.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q1" id="q1_true" value="TRUE"><label for="q1_true" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">TRUE</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q1" id="q1_false" value="FALSE"><label for="q1_false" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">FALSE</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q1" id="q1_not_given" value="NOT GIVEN"><label for="q1_not_given" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q1" id="q1_true" value="TRUE"><span class="option-control"></span><span class="mc-option-text">TRUE</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q1" id="q1_false" value="FALSE"><span class="option-control"></span><span class="mc-option-text">FALSE</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q1" id="q1_not_given" value="NOT GIVEN"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
                             </div>
                         </div>
 
                         <div class="mc-question" data-question-number="2">
                             <div class="mc-question-header"><p class="mc-question-text">2. Companies can hire people from different locations when they embrace remote work.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q2" id="q2_true" value="TRUE"><label for="q2_true" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">TRUE</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q2" id="q2_false" value="FALSE"><label for="q2_false" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">FALSE</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q2" id="q2_not_given" value="NOT GIVEN"><label for="q2_not_given" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q2" id="q2_true" value="TRUE"><span class="option-control"></span><span class="mc-option-text">TRUE</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q2" id="q2_false" value="FALSE"><span class="option-control"></span><span class="mc-option-text">FALSE</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q2" id="q2_not_given" value="NOT GIVEN"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
                             </div>
                         </div>
 
                         <div class="mc-question" data-question-number="3">
                             <div class="mc-question-header"><p class="mc-question-text">3. The only challenge for businesses adopting remote work is the initial technology cost.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q3" id="q3_true" value="TRUE"><label for="q3_true" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">TRUE</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q3" id="q3_false" value="FALSE"><label for="q3_false" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">FALSE</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q3" id="q3_not_given" value="NOT GIVEN"><label for="q3_not_given" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q3" id="q3_true" value="TRUE"><span class="option-control"></span><span class="mc-option-text">TRUE</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q3" id="q3_false" value="FALSE"><span class="option-control"></span><span class="mc-option-text">FALSE</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q3" id="q3_not_given" value="NOT GIVEN"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
                             </div>
                         </div>
 
                         <div class="mc-question" data-question-number="4">
                             <div class="mc-question-header"><p class="mc-question-text">4. Employees who work remotely save money on transportation.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q4" id="q4_true" value="TRUE"><label for="q4_true" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">TRUE</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q4" id="q4_false" value="FALSE"><label for="q4_false" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">FALSE</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q4" id="q4_not_given" value="NOT GIVEN"><label for="q4_not_given" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q4" id="q4_true" value="TRUE"><span class="option-control"></span><span class="mc-option-text">TRUE</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q4" id="q4_false" value="FALSE"><span class="option-control"></span><span class="mc-option-text">FALSE</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q4" id="q4_not_given" value="NOT GIVEN"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
                             </div>
                         </div>
 
                         <div class="mc-question" data-question-number="5">
                             <div class="mc-question-header"><p class="mc-question-text">5. All remote workers report a better work-life balance.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q5" id="q5_true" value="TRUE"><label for="q5_true" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">TRUE</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q5" id="q5_false" value="FALSE"><label for="q5_false" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">FALSE</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q5" id="q5_not_given" value="NOT GIVEN"><label for="q5_not_given" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q5" id="q5_true" value="TRUE"><span class="option-control"></span><span class="mc-option-text">TRUE</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q5" id="q5_false" value="FALSE"><span class="option-control"></span><span class="mc-option-text">FALSE</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q5" id="q5_not_given" value="NOT GIVEN"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
                             </div>
                         </div>
 
                         <div class="mc-question" data-question-number="6">
                             <div class="mc-question-header"><p class="mc-question-text">6. Suburban economies may benefit from the increase in remote work.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q6" id="q6_true" value="TRUE"><label for="q6_true" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">TRUE</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q6" id="q6_false" value="FALSE"><label for="q6_false" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">FALSE</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q6" id="q6_not_given" value="NOT GIVEN"><label for="q6_not_given" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q6" id="q6_true" value="TRUE"><span class="option-control"></span><span class="mc-option-text">TRUE</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q6" id="q6_false" value="FALSE"><span class="option-control"></span><span class="mc-option-text">FALSE</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q6" id="q6_not_given" value="NOT GIVEN"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
                             </div>
                         </div>
 
@@ -890,40 +906,40 @@
                         <div class="mc-question" data-question-number="14">
                             <div class="mc-question-header"><p class="mc-question-text">14. A description of a building that copies a natural cooling method.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q14" id="q14_a" value="A"><label for="q14_a" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">A</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q14" id="q14_b" value="B"><label for="q14_b" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">B</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q14" id="q14_c" value="C"><label for="q14_c" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">C</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q14" id="q14_d" value="D"><label for="q14_d" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">D</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q14" id="q14_a" value="A"><span class="option-control"></span><span class="mc-option-text">A</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q14" id="q14_b" value="B"><span class="option-control"></span><span class="mc-option-text">B</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q14" id="q14_c" value="C"><span class="option-control"></span><span class="mc-option-text">C</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q14" id="q14_d" value="D"><span class="option-control"></span><span class="mc-option-text">D</span></label></div>
                             </div>
                         </div>
 
                         <div class="mc-question" data-question-number="15">
                             <div class="mc-question-header"><p class="mc-question-text">15. A definition of biomimicry and its guiding philosophy.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q15" id="q15_a" value="A"><label for="q15_a" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">A</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q15" id="q15_b" value="B"><label for="q15_b" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">B</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q15" id="q15_c" value="C"><label for="q15_c" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">C</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q15" id="q15_d" value="D"><label for="q15_d" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">D</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q15" id="q15_a" value="A"><span class="option-control"></span><span class="mc-option-text">A</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q15" id="q15_b" value="B"><span class="option-control"></span><span class="mc-option-text">B</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q15" id="q15_c" value="C"><span class="option-control"></span><span class="mc-option-text">C</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q15" id="q15_d" value="D"><span class="option-control"></span><span class="mc-option-text">D</span></label></div>
                             </div>
                         </div>
 
                         <div class="mc-question" data-question-number="16">
                             <div class="mc-question-header"><p class="mc-question-text">16. The suggestion that biomimicry involves viewing nature differently.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q16" id="q16_a" value="A"><label for="q16_a" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">A</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q16" id="q16_b" value="B"><label for="q16_b" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">B</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q16" id="q16_c" value="C"><label for="q16_c" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">C</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q16" id="q16_d" value="D"><label for="q16_d" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">D</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q16" id="q16_a" value="A"><span class="option-control"></span><span class="mc-option-text">A</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q16" id="q16_b" value="B"><span class="option-control"></span><span class="mc-option-text">B</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q16" id="q16_c" value="C"><span class="option-control"></span><span class="mc-option-text">C</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q16" id="q16_d" value="D"><span class="option-control"></span><span class="mc-option-text">D</span></label></div>
                             </div>
                         </div>
 
                         <div class="mc-question" data-question-number="17">
                             <div class="mc-question-header"><p class="mc-question-text">17. The story of an invention inspired by a plant's seeds.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q17" id="q17_a" value="A"><label for="q17_a" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">A</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q17" id="q17_b" value="B"><label for="q17_b" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">B</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q17" id="q17_c" value="C"><label for="q17_c" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">C</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q17" id="q17_d" value="D"><label for="q17_d" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">D</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q17" id="q17_a" value="A"><span class="option-control"></span><span class="mc-option-text">A</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q17" id="q17_b" value="B"><span class="option-control"></span><span class="mc-option-text">B</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q17" id="q17_c" value="C"><span class="option-control"></span><span class="mc-option-text">C</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q17" id="q17_d" value="D"><span class="option-control"></span><span class="mc-option-text">D</span></label></div>
                             </div>
                         </div>
 
@@ -983,54 +999,54 @@
                         <div class="mc-question" data-question-number="27">
                             <div class="mc-question-header"><p class="mc-question-text">27. The writer believes that letter writing is completely outdated and has no place in the modern world.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q27" id="q27_yes" value="YES"><label for="q27_yes" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">YES</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q27" id="q27_no" value="NO"><label for="q27_no" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NO</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q27" id="q27_not_given" value="NOT GIVEN"><label for="q27_not_given" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q27" id="q27_yes" value="YES"><span class="option-control"></span><span class="mc-option-text">YES</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q27" id="q27_no" value="NO"><span class="option-control"></span><span class="mc-option-text">NO</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q27" id="q27_not_given" value="NOT GIVEN"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
                             </div>
                         </div>
 
                         <div class="mc-question" data-question-number="28">
                             <div class="mc-question-header"><p class="mc-question-text">28. The slowness of writing a letter can be a positive attribute.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q28" id="q28_yes" value="YES"><label for="q28_yes" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">YES</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q28" id="q28_no" value="NO"><label for="q28_no" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NO</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q28" id="q28_not_given" value="NOT GIVEN"><label for="q28_not_given" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q28" id="q28_yes" value="YES"><span class="option-control"></span><span class="mc-option-text">YES</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q28" id="q28_no" value="NO"><span class="option-control"></span><span class="mc-option-text">NO</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q28" id="q28_not_given" value="NOT GIVEN"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
                             </div>
                         </div>
 
                         <div class="mc-question" data-question-number="29">
                             <div class="mc-question-header"><p class="mc-question-text">29. The handwriting on a letter is an important part of its overall message.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q29" id="q29_yes" value="YES"><label for="q29_yes" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">YES</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q29" id="q29_no" value="NO"><label for="q29_no" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NO</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q29" id="q29_not_given" value="NOT GIVEN"><label for="q29_not_given" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q29" id="q29_yes" value="YES"><span class="option-control"></span><span class="mc-option-text">YES</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q29" id="q29_no" value="NO"><span class="option-control"></span><span class="mc-option-text">NO</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q29" id="q29_not_given" value="NOT GIVEN"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
                             </div>
                         </div>
 
                         <div class="mc-question" data-question-number="30">
                             <div class="mc-question-header"><p class="mc-question-text">30. People in the past wrote more letters because they had more free time.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q30" id="q30_yes" value="YES"><label for="q30_yes" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">YES</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q30" id="q30_no" value="NO"><label for="q30_no" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NO</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q30" id="q30_not_given" value="NOT GIVEN"><label for="q30_not_given" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q30" id="q30_yes" value="YES"><span class="option-control"></span><span class="mc-option-text">YES</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q30" id="q30_no" value="NO"><span class="option-control"></span><span class="mc-option-text">NO</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q30" id="q30_not_given" value="NOT GIVEN"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
                             </div>
                         </div>
 
                         <div class="mc-question" data-question-number="31">
                             <div class="mc-question-header"><p class="mc-question-text">31. The writer acknowledges the essential role of digital communication in today's world.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q31" id="q31_yes" value="YES"><label for="q31_yes" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">YES</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q31" id="q31_no" value="NO"><label for="q31_no" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NO</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q31" id="q31_not_given" value="NOT GIVEN"><label for="q31_not_given" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q31" id="q31_yes" value="YES"><span class="option-control"></span><span class="mc-option-text">YES</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q31" id="q31_no" value="NO"><span class="option-control"></span><span class="mc-option-text">NO</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q31" id="q31_not_given" value="NOT GIVEN"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
                             </div>
                         </div>
 
                         <div class="mc-question" data-question-number="32">
                             <div class="mc-question-header"><p class="mc-question-text">32. The writer suggests that digital communication and letter writing can coexist.</p></div>
                             <div class="mc-options-container">
-                                <div class="mc-option-item"><input type="radio" name="q32" id="q32_yes" value="YES"><label for="q32_yes" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">YES</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q32" id="q32_no" value="NO"><label for="q32_no" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NO</span></label></div>
-                                <div class="mc-option-item"><input type="radio" name="q32" id="q32_not_given" value="NOT GIVEN"><label for="q32_not_given" class="mc-option-label"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q32" id="q32_yes" value="YES"><span class="option-control"></span><span class="mc-option-text">YES</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q32" id="q32_no" value="NO"><span class="option-control"></span><span class="mc-option-text">NO</span></label></div>
+                                <div class="mc-option-item"><label class="mc-option-label"><input type="radio" name="q32" id="q32_not_given" value="NOT GIVEN"><span class="option-control"></span><span class="mc-option-text">NOT GIVEN</span></label></div>
                             </div>
                         </div>
 
@@ -1068,6 +1084,18 @@
 document.addEventListener('DOMContentLoaded', () => {
     // --- Configuration Constants ---
     const EXAM_LEVEL = 'B2';
+
+    const STORAGE_KEY = `examState-${EXAM_LEVEL}`;
+
+    const LEGACY_STORAGE_KEY = 'examState';
+
+    if (LEGACY_STORAGE_KEY !== STORAGE_KEY && localStorage.getItem(LEGACY_STORAGE_KEY)) {
+
+        localStorage.removeItem(LEGACY_STORAGE_KEY);
+
+    }
+
+    const supportsHasSelector = typeof CSS !== 'undefined' && CSS.supports && CSS.supports('selector(:has(*))');
     const GS_WEB_APP_URL = 'https://script.google.com/macros/s/AKfycbyuncyjolsXX1u9plOYDzujafMIROGIkOOjZsn2ko_lbhNbU1mAXZXa5iMHaEKReTPX/exec';
     const TOTAL_EXAM_TIME = 3600; // 60 minutes in seconds
     const SUBMISSION_TIMEOUT_MS = 12000;
@@ -1091,6 +1119,28 @@ document.addEventListener('DOMContentLoaded', () => {
     let remainingTime = TOTAL_EXAM_TIME;
     let timerInterval = null;
     let currentPassageIndex = 0;
+
+    const styleRadioGroup = (radioName) => {
+        if (supportsHasSelector || !radioName) return;
+        const radios = document.querySelectorAll(`input[type="radio"][name="${radioName}"]`);
+        radios.forEach(radio => {
+            const label = radio.closest('.mc-option-label');
+            if (label) {
+                label.classList.toggle('is-checked', radio.checked);
+            }
+        });
+    };
+
+    const refreshAllRadioStyles = () => {
+        if (supportsHasSelector) return;
+        const processed = new Set();
+        document.querySelectorAll('input[type="radio"]').forEach(radio => {
+            if (radio.name && !processed.has(radio.name)) {
+                processed.add(radio.name);
+                styleRadioGroup(radio.name);
+            }
+        });
+    };
 
     // --- DOM Element References ---
     const screens = {
@@ -1168,7 +1218,7 @@ document.addEventListener('DOMContentLoaded', () => {
             remainingTime: remainingTime
         };
         try {
-            localStorage.setItem('examState', JSON.stringify(state));
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
         } catch (e) {
             console.error("Error saving state to localStorage:", e);
         }
@@ -1179,7 +1229,7 @@ document.addEventListener('DOMContentLoaded', () => {
      */
     const loadState = () => {
         try {
-            const savedState = JSON.parse(localStorage.getItem('examState'));
+            const savedState = JSON.parse(localStorage.getItem(STORAGE_KEY));
             if (savedState && savedState.studentID) {
                 studentIdInput.value = savedState.studentID;
             }
@@ -1201,7 +1251,10 @@ document.addEventListener('DOMContentLoaded', () => {
             const radioInputs = document.querySelectorAll(`input[name="q${qNum}"]`);
             if (radioInputs.length > 0) {
                 const inputToSelect = Array.from(radioInputs).find(input => input.value === answer);
-                if (inputToSelect) inputToSelect.checked = true;
+                if (inputToSelect) {
+                    inputToSelect.checked = true;
+                    styleRadioGroup(inputToSelect.name);
+                }
             } else {
                 // Handle text inputs, including the new inline ones for questions 33-40
                 const textInput = document.getElementById(`q${qNum}`);
@@ -1210,6 +1263,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
         });
+        refreshAllRadioStyles();
     };
     
     /**
@@ -1231,6 +1285,7 @@ document.addEventListener('DOMContentLoaded', () => {
             targetElement.focus({ preventScroll: true });
             targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
+        refreshAllRadioStyles();
     };
 
     /**
@@ -1415,6 +1470,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
             if (qNum) {
                 answers[qNum] = target.value;
+                if (target.type === 'radio') {
+                    styleRadioGroup(target.name);
+                }
                 saveState();
             }
         }
@@ -1431,7 +1489,7 @@ document.addEventListener('DOMContentLoaded', () => {
         studentID = enteredID;
 
         try {
-            const savedState = JSON.parse(localStorage.getItem('examState'));
+            const savedState = JSON.parse(localStorage.getItem(STORAGE_KEY));
             if (savedState && savedState.studentID === studentID) {
                 restoreSession(savedState);
             } else {
@@ -1477,6 +1535,7 @@ document.addEventListener('DOMContentLoaded', () => {
     currentLevelDisplay.textContent = `Current Level: ${EXAM_LEVEL}`;
     loadState();
     showScreen('studentId');
+    refreshAllRadioStyles();
 
 });
 

--- a/C1/C1.html
+++ b/C1/C1.html
@@ -79,7 +79,7 @@
       --dur-3: 320ms;
 
       /* Mobile-safe touch target */
-      --target-min: 44px;
+      --target-min: 38px;
 
       /* Container max */
       --container-max: 900px;
@@ -494,6 +494,13 @@
 
     .mc-option-label:hover { background-color: var(--hover-sage); }
 
+    .mc-option-label:has(input[type="radio"]:checked),
+    .mc-option-label.is-checked {
+      border-color: color-mix(in srgb, var(--primary-sage) 55%, transparent);
+      background-color: color-mix(in srgb, var(--primary-sage) 12%, #fff 88%);
+      box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary-sage) 45%, transparent 55%);
+    }
+
     .mc-option-item .option-control {
       flex-shrink: 0;
       inline-size: 24px;
@@ -506,9 +513,11 @@
       box-shadow: inset 0 1px 0 rgba(255,255,255,0.7);
     }
 
-    .mc-option-item input[type="radio"]:checked + .option-control { border-color: var(--primary-sage); }
+    .mc-option-label input[type="radio"]:checked + .option-control,
+    .mc-option-item input[type="radio"]:checked + label .option-control { border-color: var(--primary-sage); }
 
-    .mc-option-item input[type="radio"]:checked + .option-control::after {
+    .mc-option-label input[type="radio"]:checked + .option-control::after,
+    .mc-option-item input[type="radio"]:checked + label .option-control::after {
       content: '';
       position: absolute;
       inset: 50% auto auto 50%;
@@ -526,10 +535,17 @@
       font-size: 1rem;
     }
 
-    .mc-option-item input[type="radio"]:focus-visible + .option-control,
+    .mc-option-label input[type="radio"]:focus-visible + .option-control,
+    .mc-option-item input[type="radio"]:focus-visible + label .option-control {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
     .mc-option-label:focus-visible {
       outline: none;
       box-shadow: var(--ring);
+      border-color: color-mix(in srgb, var(--primary-sage) 55%, transparent);
+      background-color: color-mix(in srgb, var(--primary-sage) 12%, #fff 88%);
     }
 
     /* Slide controls */
@@ -717,8 +733,8 @@
       display: inline-flex;
       align-items: center;
       width: clamp(6.5ch, 24vw, 11ch);
-      min-height: 2.5rem;
-      padding: 0.4em 0.55em;
+      min-height: clamp(2rem, 4.8vw, 2.3rem);
+      padding: 0.35em 0.5em;
       margin: 0 0.25em 0.3em;
       font: inherit;
       line-height: 1.2;
@@ -1066,6 +1082,18 @@
         document.addEventListener('DOMContentLoaded', () => {
             // --- CONSTANTS AND STATE ---
             const EXAM_LEVEL = 'C1';
+
+            const STORAGE_KEY = `examState-${EXAM_LEVEL}`;
+
+            const LEGACY_STORAGE_KEY = 'examState';
+
+            if (LEGACY_STORAGE_KEY !== STORAGE_KEY && localStorage.getItem(LEGACY_STORAGE_KEY)) {
+
+                localStorage.removeItem(LEGACY_STORAGE_KEY);
+
+            }
+
+            const supportsHasSelector = typeof CSS !== 'undefined' && CSS.supports && CSS.supports('selector(:has(*))');
             const GS_WEB_APP_URL = 'https://script.google.com/macros/s/AKfycbyuncyjolsXX1u9plOYDzujafMIROGIkOOjZsn2ko_lbhNbU1mAXZXa5iMHaEKReTPX/exec';
             const TOTAL_TIME = 3600; // 60 minutes in seconds
             const SUBMISSION_TIMEOUT_MS = 12000;
@@ -1090,6 +1118,28 @@
             let timerInterval = null;
             let timeSaveInterval = null;
             let currentPassageIndex = 0;
+
+            const styleRadioGroup = (radioName) => {
+                if (supportsHasSelector || !radioName) return;
+                const radios = document.querySelectorAll(`input[type="radio"][name="${radioName}"]`);
+                radios.forEach(radio => {
+                    const label = radio.closest('.mc-option-label');
+                    if (label) {
+                        label.classList.toggle('is-checked', radio.checked);
+                    }
+                });
+            };
+
+            const refreshAllRadioStyles = () => {
+                if (supportsHasSelector) return;
+                const processed = new Set();
+                document.querySelectorAll('input[type="radio"]').forEach(radio => {
+                    if (radio.name && !processed.has(radio.name)) {
+                        processed.add(radio.name);
+                        styleRadioGroup(radio.name);
+                    }
+                });
+            };
 
             // --- DOM ELEMENTS ---
             const screens = {
@@ -1122,7 +1172,7 @@
 
             const saveState = () => {
                 try {
-                    localStorage.setItem('examState', JSON.stringify(studentState));
+                    localStorage.setItem(STORAGE_KEY, JSON.stringify(studentState));
                 } catch (e) {
                     console.error("Failed to save state to localStorage:", e);
                 }
@@ -1130,7 +1180,7 @@
             
             const loadState = () => {
                 try {
-                    const savedState = localStorage.getItem('examState');
+                    const savedState = localStorage.getItem(STORAGE_KEY);
                     if (savedState) {
                         const parsedState = JSON.parse(savedState);
                         // Only pre-fill ID. The rest is loaded when the user confirms the ID.
@@ -1140,7 +1190,7 @@
                     }
                 } catch (e) {
                     console.error("Failed to load state from localStorage:", e);
-                    localStorage.removeItem('examState');
+                    localStorage.removeItem(STORAGE_KEY);
                 }
             };
 
@@ -1151,10 +1201,9 @@
                     const radioInputs = document.querySelectorAll(`input[name="q${qNum}"]`);
                     if (radioInputs.length > 0) {
                         radioInputs.forEach(input => {
-                            if (input.value === value) {
-                                input.checked = true;
-                            }
+                            input.checked = input.value === value;
                         });
+                        styleRadioGroup(radioInputs[0].name);
                     }
                     // Handle Text and Select inputs by data-question-number
                     const otherInput = document.querySelector(`[data-question-number="${qNum}"]`);
@@ -1162,6 +1211,7 @@
                         otherInput.value = value;
                     }
                 });
+                refreshAllRadioStyles();
             };
 
             const updateTimerDisplay = () => {
@@ -1210,6 +1260,7 @@
                 if (firstHeading) {
                     firstHeading.focus();
                 }
+                refreshAllRadioStyles();
             };
 
             const handleAnswerChange = (e) => {
@@ -1226,6 +1277,9 @@
                 
                 if (qNum) {
                     studentState.answers[qNum] = target.value.trim();
+                    if (target.type === 'radio') {
+                        styleRadioGroup(target.name);
+                    }
                     saveState();
                 }
             };
@@ -1378,7 +1432,7 @@
                     return;
                 }
                 
-                const savedStateRaw = localStorage.getItem('examState');
+                const savedStateRaw = localStorage.getItem(STORAGE_KEY);
                 if (savedStateRaw) {
                     const savedState = JSON.parse(savedStateRaw);
                     if (savedState.studentID === enteredID) {
@@ -1431,6 +1485,7 @@
             // --- INITIALIZATION ---
             currentLevelDisplay.textContent = `Current Level: ${EXAM_LEVEL}`;
             loadState();
+            refreshAllRadioStyles();
         });
 
         /*


### PR DESCRIPTION
## Summary
- Normalize radio option markup and add checked-state styling with :has selectors and JavaScript fallbacks across every exam level.
- Tighten inline text input dimensions by lowering the shared target height and adjusting padding for better mobile ergonomics.
- Namespace saved progress per level and remove legacy keys while keeping radio highlights in sync with restored answers.

## Testing
- Not run (HTML-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d33ef16eac83269fc3157bfdb7a24c