### PR TITLE
Improve offline resilience of reading exams

### DIFF
--- a/A1/A1.html
+++ b/A1/A1.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Level A1 End of Year Reading Exam</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;700;800&family=Questrial&display=swap" rel="stylesheet">
     <style>
     /* =====================================================================
        Organic Sage UI — Mobile-first, stable, and soothing
@@ -37,8 +34,8 @@
       --ink-muted: #5A6B52;
 
       /* Typography */
-      --font-display: 'Questrial', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, sans-serif;
-      --font-body: 'Nunito', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, sans-serif;
+      --font-display: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+      --font-body: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
 
       /* Fluid typography scale */
       --step--1: clamp(0.875rem, 0.84rem + 0.15vw, 0.95rem);
@@ -109,6 +106,7 @@
       font-size: var(--step-0);
       line-height: 1.6;
       color: var(--forest-shadow);
+      background-color: var(--warm-cream);
       background:
         radial-gradient(1200px 1200px at -10% -10%, #FFFFFF 0%, transparent 50%),
         radial-gradient(1200px 1000px at 110% 10%, #FFF8F0 0%, transparent 50%),
@@ -121,6 +119,21 @@
 
     @media (prefers-reduced-motion: no-preference) {
       html { scroll-behavior: smooth; }
+    }
+
+    @media (prefers-reduced-data: reduce) {
+      body {
+        background: var(--warm-cream);
+      }
+
+      #activity-container {
+        box-shadow: none;
+        background: #fff;
+      }
+
+      .activity-btn {
+        box-shadow: none;
+      }
     }
 
     /* Better text wrapping on small screens */
@@ -799,6 +812,11 @@
     </style>
 </head>
 <body>
+    <noscript>
+        <div style="padding:1rem; background:#fff3cd; color:#664d03; text-align:center; font-weight:600;">
+            JavaScript is required to run this exam experience. Please enable it and reload the page.
+        </div>
+    </noscript>
     <div id="app-wrapper">
         <div id="activity-container">
 
@@ -1116,11 +1134,49 @@
         const STORAGE_KEY = `examState-${EXAM_LEVEL}`;
 
         const LEGACY_STORAGE_KEY = 'examState';
+        const storage = (() => {
+            let storageHealthy = true;
 
-        if (LEGACY_STORAGE_KEY !== STORAGE_KEY && localStorage.getItem(LEGACY_STORAGE_KEY)) {
+            const testAvailability = () => {
+                try {
+                    const testKey = '__exam_storage_test__';
+                    window.localStorage.setItem(testKey, '1');
+                    window.localStorage.removeItem(testKey);
+                    return true;
+                } catch (error) {
+                    console.warn('Local storage unavailable, falling back to memory only mode.', error);
+                    return false;
+                }
+            };
 
-            localStorage.removeItem(LEGACY_STORAGE_KEY);
+            const isSupported = typeof window !== 'undefined' && 'localStorage' in window && testAvailability();
 
+            const safeRun = (operation) => {
+                if (!isSupported || !storageHealthy) {
+                    return null;
+                }
+
+                try {
+                    return operation();
+                } catch (error) {
+                    storageHealthy = false;
+                    console.warn('Local storage operation failed, disabling further writes.', error);
+                    return null;
+                }
+            };
+
+            return {
+                getItem: (key) => safeRun(() => window.localStorage.getItem(key)),
+                setItem: (key, value) => safeRun(() => window.localStorage.setItem(key, value)),
+                removeItem: (key) => safeRun(() => window.localStorage.removeItem(key)),
+                isAvailable: () => isSupported && storageHealthy
+            };
+        })();
+
+        let fallbackState = null;
+
+        if (LEGACY_STORAGE_KEY !== STORAGE_KEY && storage.getItem(LEGACY_STORAGE_KEY)) {
+            storage.removeItem(LEGACY_STORAGE_KEY);
         }
 
         const supportsHasSelector = typeof CSS !== 'undefined' && CSS.supports && CSS.supports('selector(:has(*))');
@@ -1155,6 +1211,32 @@
         const downloadCsvBtn = document.getElementById('download-csv-btn');
         const submitBtn = document.getElementById('submit-btn');
         const submissionStatus = document.getElementById('submission-status');
+
+        const getStoredState = () => {
+            const rawState = storage.getItem(STORAGE_KEY);
+            if (rawState) {
+                try {
+                    return JSON.parse(rawState);
+                } catch (error) {
+                    console.warn('Saved state could not be parsed. Resetting.', error);
+                }
+            }
+            return fallbackState;
+        };
+
+        const persistState = (state) => {
+            fallbackState = state;
+            if (storage.isAvailable()) {
+                storage.setItem(STORAGE_KEY, JSON.stringify(state));
+            }
+        };
+
+        const clearPersistedState = () => {
+            fallbackState = null;
+            if (storage.isAvailable()) {
+                storage.removeItem(STORAGE_KEY);
+            }
+        };
 
         // --- STATE VARIABLES ---
         let studentID = '';
@@ -1232,10 +1314,10 @@
                 return;
             }
 
-            const savedState = JSON.parse(localStorage.getItem(STORAGE_KEY));
+            const savedState = getStoredState();
             if (savedState && savedState.studentID !== enteredID) {
                 // New student, reset state
-                localStorage.removeItem(STORAGE_KEY);
+                clearPersistedState();
                 studentID = enteredID;
                 studentAnswers = {};
                 remainingTime = TOTAL_TIME;
@@ -1250,8 +1332,9 @@
 
         // --- STATE MANAGEMENT (LOCAL STORAGE) ---
         function loadState() {
-            const savedState = JSON.parse(localStorage.getItem(STORAGE_KEY));
+            const savedState = getStoredState();
             if (savedState) {
+                fallbackState = savedState;
                 studentIdInput.value = savedState.studentID || '';
                 studentAnswers = savedState.answers || {};
                 remainingTime = savedState.remainingTime || TOTAL_TIME;
@@ -1267,7 +1350,7 @@
                 answers: studentAnswers,
                 remainingTime: remainingTime
             };
-            localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+            persistState(state);
         }
 
         function populateAnswers() {
@@ -1454,7 +1537,7 @@
                 if (result.result === 'success') {
                     submissionStatus.textContent = 'Successfully submitted!';
                     submissionStatus.style.color = '#2E7D32';
-                    localStorage.removeItem(STORAGE_KEY);
+                    clearPersistedState();
                     submissionConfirmed = true;
                     return;
                 }

--- a/A2-plus/A2-plus.html
+++ b/A2-plus/A2-plus.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Level A2+ End of Year Reading Exam</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;700;800&family=Questrial&display=swap" rel="stylesheet">
     <style>
     /* =====================================================================
        Organic Sage UI — Mobile-first, stable, and soothing
@@ -37,8 +34,8 @@
       --ink-muted: #5A6B52;
 
       /* Typography */
-      --font-display: 'Questrial', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, sans-serif;
-      --font-body: 'Nunito', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, sans-serif;
+      --font-display: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+      --font-body: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
 
       /* Fluid typography scale */
       --step--1: clamp(0.875rem, 0.84rem + 0.15vw, 0.95rem);
@@ -109,6 +106,7 @@
       font-size: var(--step-0);
       line-height: 1.6;
       color: var(--forest-shadow);
+      background-color: var(--warm-cream);
       background:
         radial-gradient(1200px 1200px at -10% -10%, #FFFFFF 0%, transparent 50%),
         radial-gradient(1200px 1000px at 110% 10%, #FFF8F0 0%, transparent 50%),
@@ -121,6 +119,21 @@
 
     @media (prefers-reduced-motion: no-preference) {
       html { scroll-behavior: smooth; }
+    }
+
+    @media (prefers-reduced-data: reduce) {
+      body {
+        background: var(--warm-cream);
+      }
+
+      #activity-container {
+        box-shadow: none;
+        background: #fff;
+      }
+
+      .activity-btn {
+        box-shadow: none;
+      }
     }
 
     /* Better text wrapping on small screens */
@@ -800,6 +813,12 @@
 </head>
 <body>
 
+    <noscript>
+        <div style="padding:1rem; background:#fff3cd; color:#664d03; text-align:center; font-weight:600;">
+            JavaScript is required to run this exam experience. Please enable it and reload the page.
+        </div>
+    </noscript>
+
     <div id="app-wrapper">
         <div id="activity-container">
 
@@ -1127,10 +1146,50 @@
         const STORAGE_KEY = `examState-${EXAM_LEVEL}`;
 
         const LEGACY_STORAGE_KEY = 'examState';
+        const storage = (() => {
+            let storageHealthy = true;
 
-        if (LEGACY_STORAGE_KEY !== STORAGE_KEY && localStorage.getItem(LEGACY_STORAGE_KEY)) {
+            const testAvailability = () => {
+                try {
+                    const testKey = '__exam_storage_test__';
+                    window.localStorage.setItem(testKey, '1');
+                    window.localStorage.removeItem(testKey);
+                    return true;
+                } catch (error) {
+                    console.warn('Local storage unavailable, falling back to memory only mode.', error);
+                    return false;
+                }
+            };
 
-            localStorage.removeItem(LEGACY_STORAGE_KEY);
+            const isSupported = typeof window !== 'undefined' && 'localStorage' in window && testAvailability();
+
+            const safeRun = (operation) => {
+                if (!isSupported || !storageHealthy) {
+                    return null;
+                }
+
+                try {
+                    return operation();
+                } catch (error) {
+                    storageHealthy = false;
+                    console.warn('Local storage operation failed, disabling further writes.', error);
+                    return null;
+                }
+            };
+
+            return {
+                getItem: (key) => safeRun(() => window.localStorage.getItem(key)),
+                setItem: (key, value) => safeRun(() => window.localStorage.setItem(key, value)),
+                removeItem: (key) => safeRun(() => window.localStorage.removeItem(key)),
+                isAvailable: () => isSupported && storageHealthy
+            };
+        })();
+
+        let fallbackState = null;
+
+        if (LEGACY_STORAGE_KEY !== STORAGE_KEY && storage.getItem(LEGACY_STORAGE_KEY)) {
+
+            storage.removeItem(LEGACY_STORAGE_KEY);
 
         }
 
@@ -1170,6 +1229,32 @@
         const examForm = document.getElementById('exam-form');
         const progressBar = document.getElementById('progress-bar');
         const progressText = document.getElementById('progress-text');
+
+        const getStoredState = () => {
+            const rawState = storage.getItem(STORAGE_KEY);
+            if (rawState) {
+                try {
+                    return JSON.parse(rawState);
+                } catch (error) {
+                    console.warn('Saved state could not be parsed. Resetting.', error);
+                }
+            }
+            return fallbackState;
+        };
+
+        const persistState = (state) => {
+            fallbackState = state;
+            if (storage.isAvailable()) {
+                storage.setItem(STORAGE_KEY, JSON.stringify(state));
+            }
+        };
+
+        const clearPersistedState = () => {
+            fallbackState = null;
+            if (storage.isAvailable()) {
+                storage.removeItem(STORAGE_KEY);
+            }
+        };
 
         // --- STATE ---
         let studentID = '';
@@ -1232,36 +1317,28 @@
         };
 
         const saveState = () => {
-            try {
-                const state = {
-                    studentID,
-                    answers,
-                    remainingTime,
-                };
-                localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-            } catch (e) {
-                console.error("Could not save state to localStorage:", e);
-            }
+            const state = {
+                studentID,
+                answers,
+                remainingTime,
+            };
+            persistState(state);
         };
 
         const loadState = () => {
-            try {
-                const savedState = localStorage.getItem(STORAGE_KEY);
-                if (savedState) {
-                    const state = JSON.parse(savedState);
-                    studentIdInput.value = state.studentID || '';
-                    if (studentIdInput.value.trim() !== '') {
-                        startExamBtn.disabled = false;
-                    }
-                    // Answers and time will be restored if the same student ID is used to start the exam.
+            const state = getStoredState();
+            if (state) {
+                fallbackState = state;
+                studentIdInput.value = state.studentID || '';
+                if (studentIdInput.value.trim() !== '') {
+                    startExamBtn.disabled = false;
                 }
-            } catch (e) {
-                console.error("Could not load state from localStorage:", e);
-                localStorage.removeItem(STORAGE_KEY);
+                // Answers and time will be restored if the same student ID is used to start the exam.
             }
         };
 
         const restoreSession = (state) => {
+            fallbackState = state;
             answers = state.answers || {};
             remainingTime = state.remainingTime || TOTAL_TIME;
 
@@ -1418,6 +1495,7 @@
                 if (result.result === 'success') {
                     submissionStatusEl.textContent = 'Successfully submitted!';
                     submissionStatusEl.style.color = 'green';
+                    clearPersistedState();
                     submissionConfirmed = true;
                     return;
                 }
@@ -1461,19 +1539,19 @@
             if (!enteredID) return;
 
             studentID = enteredID;
-            
-            const savedStateJSON = localStorage.getItem(STORAGE_KEY);
-            if (savedStateJSON) {
-                const savedState = JSON.parse(savedStateJSON);
+
+            const savedState = getStoredState();
+            if (savedState) {
                 if (savedState.studentID === studentID) {
                     restoreSession(savedState);
                 } else {
                     // New student ID, so clear old answers and reset timer
+                    clearPersistedState();
                     answers = {};
                     remainingTime = TOTAL_TIME;
                 }
             }
-            
+
             saveState(); // Save the new (or confirmed) student ID
             currentLevelEl.textContent = `Current Level: ${EXAM_LEVEL}`;
             showScreen('test');

--- a/A2/A2.html
+++ b/A2/A2.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Level A2 End of Year Reading Exam</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;700;800&family=Questrial&display=swap" rel="stylesheet">
     <style>
     /* =====================================================================
        Organic Sage UI — Mobile-first, stable, and soothing
@@ -37,8 +34,8 @@
       --ink-muted: #5A6B52;
 
       /* Typography */
-      --font-display: 'Questrial', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, sans-serif;
-      --font-body: 'Nunito', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, sans-serif;
+      --font-display: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+      --font-body: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
 
       /* Fluid typography scale */
       --step--1: clamp(0.875rem, 0.84rem + 0.15vw, 0.95rem);
@@ -109,6 +106,7 @@
       font-size: var(--step-0);
       line-height: 1.6;
       color: var(--forest-shadow);
+      background-color: var(--warm-cream);
       background:
         radial-gradient(1200px 1200px at -10% -10%, #FFFFFF 0%, transparent 50%),
         radial-gradient(1200px 1000px at 110% 10%, #FFF8F0 0%, transparent 50%),
@@ -121,6 +119,21 @@
 
     @media (prefers-reduced-motion: no-preference) {
       html { scroll-behavior: smooth; }
+    }
+
+    @media (prefers-reduced-data: reduce) {
+      body {
+        background: var(--warm-cream);
+      }
+
+      #activity-container {
+        box-shadow: none;
+        background: #fff;
+      }
+
+      .activity-btn {
+        box-shadow: none;
+      }
     }
 
     /* Better text wrapping on small screens */
@@ -799,6 +812,12 @@
 </head>
 <body>
 
+    <noscript>
+        <div style="padding:1rem; background:#fff3cd; color:#664d03; text-align:center; font-weight:600;">
+            JavaScript is required to run this exam experience. Please enable it and reload the page.
+        </div>
+    </noscript>
+
     <div id="app-wrapper">
         <main id="activity-container">
 
@@ -1118,9 +1137,50 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const LEGACY_STORAGE_KEY = 'examState';
 
-    if (LEGACY_STORAGE_KEY !== STORAGE_KEY && localStorage.getItem(LEGACY_STORAGE_KEY)) {
+    const storage = (() => {
+        let storageHealthy = true;
 
-        localStorage.removeItem(LEGACY_STORAGE_KEY);
+        const testAvailability = () => {
+            try {
+                const testKey = '__exam_storage_test__';
+                window.localStorage.setItem(testKey, '1');
+                window.localStorage.removeItem(testKey);
+                return true;
+            } catch (error) {
+                console.warn('Local storage unavailable, falling back to memory only mode.', error);
+                return false;
+            }
+        };
+
+        const isSupported = typeof window !== 'undefined' && 'localStorage' in window && testAvailability();
+
+        const safeRun = (operation) => {
+            if (!isSupported || !storageHealthy) {
+                return null;
+            }
+
+            try {
+                return operation();
+            } catch (error) {
+                storageHealthy = false;
+                console.warn('Local storage operation failed, disabling further writes.', error);
+                return null;
+            }
+        };
+
+        return {
+            getItem: (key) => safeRun(() => window.localStorage.getItem(key)),
+            setItem: (key, value) => safeRun(() => window.localStorage.setItem(key, value)),
+            removeItem: (key) => safeRun(() => window.localStorage.removeItem(key)),
+            isAvailable: () => isSupported && storageHealthy
+        };
+    })();
+
+    let fallbackState = null;
+
+    if (LEGACY_STORAGE_KEY !== STORAGE_KEY && storage.getItem(LEGACY_STORAGE_KEY)) {
+
+        storage.removeItem(LEGACY_STORAGE_KEY);
 
     }
 
@@ -1136,6 +1196,32 @@ document.addEventListener('DOMContentLoaded', () => {
         '21': 'David', '22': 'third floor', '23': 'graphic designer', '24': 'supermarket and gym', '25': 'every 15 minutes', '26': 'about yourself',
         '27': 'False', '28': 'False', '29': 'True', '30': 'False', '31': 'True', '32': 'False', '33': 'False',
         '34': 'pedals', '35': 'uncomfortable', '36': 'dangerous', '37': 'chain', '38': 'size', '39': 'design', '40': 'popular'
+    };
+
+    const getStoredState = () => {
+        const rawState = storage.getItem(STORAGE_KEY);
+        if (rawState) {
+            try {
+                return JSON.parse(rawState);
+            } catch (error) {
+                console.warn('Saved state could not be parsed. Resetting.', error);
+            }
+        }
+        return fallbackState;
+    };
+
+    const persistState = (state) => {
+        fallbackState = state;
+        if (storage.isAvailable()) {
+            storage.setItem(STORAGE_KEY, JSON.stringify(state));
+        }
+    };
+
+    const clearPersistedState = () => {
+        fallbackState = null;
+        if (storage.isAvailable()) {
+            storage.removeItem(STORAGE_KEY);
+        }
     };
 
     // --- STATE VARIABLES ---
@@ -1202,44 +1288,37 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     /**
-     * Saves the current exam state to localStorage.
+     * Saves the current exam state locally.
      */
     const saveState = () => {
-        try {
-            const state = {
-                studentID: studentID,
-                answers: studentAnswers,
-                remainingTime: remainingTime,
-            };
-            localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-        } catch (error) {
-            console.error("Could not save state to localStorage:", error);
-        }
+        const state = {
+            studentID: studentID,
+            answers: studentAnswers,
+            remainingTime: remainingTime,
+        };
+        persistState(state);
     };
 
     /**
-     * Loads exam state from localStorage.
+     * Loads exam state from local storage (or memory fallback).
      */
     const loadState = () => {
-        try {
-            const savedState = localStorage.getItem(STORAGE_KEY);
-            if (savedState) {
-                const state = JSON.parse(savedState);
-                studentIdInput.value = state.studentID || '';
-                // The actual restoration of answers and timer happens in startExam()
-                // if the student ID matches the saved one.
-                validateStudentIdInput();
-            }
-        } catch (error) {
-            console.error("Could not load state from localStorage:", error);
+        const savedState = getStoredState();
+        if (savedState) {
+            fallbackState = savedState;
+            studentIdInput.value = savedState.studentID || '';
+            // The actual restoration of answers and timer happens in startExam()
+            // if the student ID matches the saved one.
+            validateStudentIdInput();
         }
     };
     
     /**
      * Restores answers and timer from a saved state object.
-     * @param {object} state - The loaded state object from localStorage.
+     * @param {object} state - The loaded state object from storage.
      */
     const restoreSession = (state) => {
+        fallbackState = state;
         studentAnswers = state.answers || {};
         remainingTime = state.remainingTime || TOTAL_TIME;
 
@@ -1492,12 +1571,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 throw new Error('Server returned an unexpected response format.');
             }
 
-            if (result.result === 'success') {
-                submissionStatus.textContent = 'Successfully submitted!';
-                submissionStatus.style.color = '#2E7D32';
-                submissionConfirmed = true;
-                return;
-            }
+        if (result.result === 'success') {
+            submissionStatus.textContent = 'Successfully submitted!';
+            submissionStatus.style.color = '#2E7D32';
+            clearPersistedState();
+            submissionConfirmed = true;
+            return;
+        }
 
             throw new Error(result.error || 'Submission failed.');
         } catch (error) {
@@ -1534,18 +1614,18 @@ document.addEventListener('DOMContentLoaded', () => {
         studentID = studentIdInput.value.trim();
         if (!studentID) return;
 
-        const savedStateJSON = localStorage.getItem(STORAGE_KEY);
-        if (savedStateJSON) {
-            const savedState = JSON.parse(savedStateJSON);
+        const savedState = getStoredState();
+        if (savedState) {
             if (savedState.studentID === studentID) {
                 restoreSession(savedState);
             } else {
                 // New student, clear old answers and reset time
+                clearPersistedState();
                 studentAnswers = {};
                 remainingTime = TOTAL_TIME;
             }
         }
-        
+
         saveState(); // Save the current (potentially new) student ID
         
         currentLevelDisplay.textContent = `Current Level: ${EXAM_LEVEL}`;

--- a/B1/B1.html
+++ b/B1/B1.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Level B1 End of Year Reading Exam</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;700;800&family=Questrial&display=swap" rel="stylesheet">
     <style>
     /* =====================================================================
        Organic Sage UI — Mobile-first, stable, and soothing
@@ -37,8 +34,8 @@
       --ink-muted: #5A6B52;
 
       /* Typography */
-      --font-display: 'Questrial', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, sans-serif;
-      --font-body: 'Nunito', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, sans-serif;
+      --font-display: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+      --font-body: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
 
       /* Fluid typography scale */
       --step--1: clamp(0.875rem, 0.84rem + 0.15vw, 0.95rem);
@@ -109,6 +106,7 @@
       font-size: var(--step-0);
       line-height: 1.6;
       color: var(--forest-shadow);
+      background-color: var(--warm-cream);
       background:
         radial-gradient(1200px 1200px at -10% -10%, #FFFFFF 0%, transparent 50%),
         radial-gradient(1200px 1000px at 110% 10%, #FFF8F0 0%, transparent 50%),
@@ -121,6 +119,21 @@
 
     @media (prefers-reduced-motion: no-preference) {
       html { scroll-behavior: smooth; }
+    }
+
+    @media (prefers-reduced-data: reduce) {
+      body {
+        background: var(--warm-cream);
+      }
+
+      #activity-container {
+        box-shadow: none;
+        background: #fff;
+      }
+
+      .activity-btn {
+        box-shadow: none;
+      }
     }
 
     /* Better text wrapping on small screens */
@@ -800,6 +813,12 @@
 </head>
 <body>
 
+    <noscript>
+        <div style="padding:1rem; background:#fff3cd; color:#664d03; text-align:center; font-weight:600;">
+            JavaScript is required to run this exam experience. Please enable it and reload the page.
+        </div>
+    </noscript>
+
     <div id="app-wrapper">
         <main id="activity-container">
 
@@ -1155,9 +1174,50 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const LEGACY_STORAGE_KEY = 'examState';
 
-    if (LEGACY_STORAGE_KEY !== STORAGE_KEY && localStorage.getItem(LEGACY_STORAGE_KEY)) {
+    const storage = (() => {
+        let storageHealthy = true;
 
-        localStorage.removeItem(LEGACY_STORAGE_KEY);
+        const testAvailability = () => {
+            try {
+                const testKey = '__exam_storage_test__';
+                window.localStorage.setItem(testKey, '1');
+                window.localStorage.removeItem(testKey);
+                return true;
+            } catch (error) {
+                console.warn('Local storage unavailable, falling back to memory only mode.', error);
+                return false;
+            }
+        };
+
+        const isSupported = typeof window !== 'undefined' && 'localStorage' in window && testAvailability();
+
+        const safeRun = (operation) => {
+            if (!isSupported || !storageHealthy) {
+                return null;
+            }
+
+            try {
+                return operation();
+            } catch (error) {
+                storageHealthy = false;
+                console.warn('Local storage operation failed, disabling further writes.', error);
+                return null;
+            }
+        };
+
+        return {
+            getItem: (key) => safeRun(() => window.localStorage.getItem(key)),
+            setItem: (key, value) => safeRun(() => window.localStorage.setItem(key, value)),
+            removeItem: (key) => safeRun(() => window.localStorage.removeItem(key)),
+            isAvailable: () => isSupported && storageHealthy
+        };
+    })();
+
+    let fallbackState = null;
+
+    if (LEGACY_STORAGE_KEY !== STORAGE_KEY && storage.getItem(LEGACY_STORAGE_KEY)) {
+
+        storage.removeItem(LEGACY_STORAGE_KEY);
 
     }
 
@@ -1173,6 +1233,32 @@ document.addEventListener('DOMContentLoaded', () => {
         '19': 'wealthy individuals', '20': 'mid-19th century', '21': 'industrialist', '22': 'the land', '23': 'education', '24': 'community hubs', '25': 'adapted', '26': 'core mission',
         '27': 'B', '28': 'B', '29': 'C', '30': 'C', '31': 'B', '32': 'B', '33': 'C',
         '34': 'H', '35': 'B', '36': 'A', '37': 'G', '38': 'E', '39': 'C', '40': 'D'
+    };
+
+    const getStoredState = () => {
+        const rawState = storage.getItem(STORAGE_KEY);
+        if (rawState) {
+            try {
+                return JSON.parse(rawState);
+            } catch (error) {
+                console.warn('Saved state could not be parsed. Resetting.', error);
+            }
+        }
+        return fallbackState;
+    };
+
+    const persistState = (nextState) => {
+        fallbackState = nextState;
+        if (storage.isAvailable()) {
+            storage.setItem(STORAGE_KEY, JSON.stringify(nextState));
+        }
+    };
+
+    const clearPersistedState = () => {
+        fallbackState = null;
+        if (storage.isAvailable()) {
+            storage.removeItem(STORAGE_KEY);
+        }
     };
 
     // --- STATE ---
@@ -1259,36 +1345,27 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    // --- STATE MANAGEMENT (LOCAL STORAGE) ---
+    // --- STATE MANAGEMENT ---
     function saveStateToLocalStorage() {
-        try {
-            localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-        } catch (e) {
-            console.error("Could not save state to localStorage:", e);
-        }
+        persistState(state);
     }
 
     function loadStateFromLocalStorage() {
-        try {
-            const savedState = localStorage.getItem(STORAGE_KEY);
-            if (savedState) {
-                const parsedState = JSON.parse(savedState);
-                // Pre-fill student ID from saved state
-                if (parsedState.studentID) {
-                    studentIdInput.value = parsedState.studentID;
-                    startExamBtn.disabled = false;
-                }
+        const savedState = getStoredState();
+        if (savedState) {
+            fallbackState = savedState;
+            if (savedState.studentID) {
+                studentIdInput.value = savedState.studentID;
+                startExamBtn.disabled = false;
             }
-        } catch (e) {
-            console.error("Could not load state from localStorage:", e);
-            localStorage.removeItem(STORAGE_KEY);
         }
     }
-    
+
     function restoreSessionIfMatched(enteredID) {
-        const savedState = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
-        if (savedState.studentID === enteredID) {
+        const savedState = getStoredState();
+        if (savedState && savedState.studentID === enteredID) {
             state = { ...state, ...savedState };
+            fallbackState = state;
             
             // Restore answers
             Object.keys(state.answers).forEach(qNum => {
@@ -1320,9 +1397,22 @@ document.addEventListener('DOMContentLoaded', () => {
             alert("Please enter your Student ID.");
             return;
         }
-        
-        restoreSessionIfMatched(enteredID);
-        state.studentID = enteredID;
+
+        const savedState = getStoredState();
+        if (savedState && savedState.studentID !== enteredID) {
+            clearPersistedState();
+            state = {
+                studentID: enteredID,
+                answers: {},
+                remainingTime: TOTAL_TIME,
+                currentPassageIndex: 0
+            };
+        } else {
+            restoreSessionIfMatched(enteredID);
+            state.studentID = enteredID;
+        }
+
+        saveStateToLocalStorage();
 
         showScreen('test');
         showPassage(state.currentPassageIndex);
@@ -1523,6 +1613,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (result.result === 'success') {
                 submissionStatus.textContent = 'Successfully submitted!';
                 submissionStatus.style.color = '#2E7D32';
+                clearPersistedState();
                 submissionConfirmed = true;
                 return;
             }

--- a/B2/B2.html
+++ b/B2/B2.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Level B2 End of Year Reading Exam</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;700;800&family=Questrial&display=swap" rel="stylesheet">
     <style>
     /* =====================================================================
        Organic Sage UI — Mobile-first, stable, and soothing
@@ -37,8 +34,8 @@
       --ink-muted: #5A6B52;
 
       /* Typography */
-      --font-display: 'Questrial', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, sans-serif;
-      --font-body: 'Nunito', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, sans-serif;
+      --font-display: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+      --font-body: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
 
       /* Fluid typography scale */
       --step--1: clamp(0.875rem, 0.84rem + 0.15vw, 0.95rem);
@@ -109,6 +106,7 @@
       font-size: var(--step-0);
       line-height: 1.6;
       color: var(--forest-shadow);
+      background-color: var(--warm-cream);
       background:
         radial-gradient(1200px 1200px at -10% -10%, #FFFFFF 0%, transparent 50%),
         radial-gradient(1200px 1000px at 110% 10%, #FFF8F0 0%, transparent 50%),
@@ -121,6 +119,21 @@
 
     @media (prefers-reduced-motion: no-preference) {
       html { scroll-behavior: smooth; }
+    }
+
+    @media (prefers-reduced-data: reduce) {
+      body {
+        background: var(--warm-cream);
+      }
+
+      #activity-container {
+        box-shadow: none;
+        background: #fff;
+      }
+
+      .activity-btn {
+        box-shadow: none;
+      }
     }
 
     /* Better text wrapping on small screens */
@@ -808,6 +821,12 @@
 </head>
 <body>
 
+    <noscript>
+        <div style="padding:1rem; background:#fff3cd; color:#664d03; text-align:center; font-weight:600;">
+            JavaScript is required to run this exam experience. Please enable it and reload the page.
+        </div>
+    </noscript>
+
     <div id="app-wrapper">
         <main id="activity-container">
 
@@ -1141,9 +1160,50 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const LEGACY_STORAGE_KEY = 'examState';
 
-    if (LEGACY_STORAGE_KEY !== STORAGE_KEY && localStorage.getItem(LEGACY_STORAGE_KEY)) {
+    const storage = (() => {
+        let storageHealthy = true;
 
-        localStorage.removeItem(LEGACY_STORAGE_KEY);
+        const testAvailability = () => {
+            try {
+                const testKey = '__exam_storage_test__';
+                window.localStorage.setItem(testKey, '1');
+                window.localStorage.removeItem(testKey);
+                return true;
+            } catch (error) {
+                console.warn('Local storage unavailable, falling back to memory only mode.', error);
+                return false;
+            }
+        };
+
+        const isSupported = typeof window !== 'undefined' && 'localStorage' in window && testAvailability();
+
+        const safeRun = (operation) => {
+            if (!isSupported || !storageHealthy) {
+                return null;
+            }
+
+            try {
+                return operation();
+            } catch (error) {
+                storageHealthy = false;
+                console.warn('Local storage operation failed, disabling further writes.', error);
+                return null;
+            }
+        };
+
+        return {
+            getItem: (key) => safeRun(() => window.localStorage.getItem(key)),
+            setItem: (key, value) => safeRun(() => window.localStorage.setItem(key, value)),
+            removeItem: (key) => safeRun(() => window.localStorage.removeItem(key)),
+            isAvailable: () => isSupported && storageHealthy
+        };
+    })();
+
+    let fallbackState = null;
+
+    if (LEGACY_STORAGE_KEY !== STORAGE_KEY && storage.getItem(LEGACY_STORAGE_KEY)) {
+
+        storage.removeItem(LEGACY_STORAGE_KEY);
 
     }
 
@@ -1163,6 +1223,32 @@ document.addEventListener('DOMContentLoaded', () => {
         '27': 'NO', '28': 'YES', '29': 'YES', '30': 'NOT GIVEN', '31': 'YES', '32': 'YES',
         '33': 'considered', '34': 'emotional', '35': 'tangible', '36': 'connection',
         '37': 'attention', '38': 'speed', '39': 'competition', '40': 'value'
+    };
+
+    const getStoredState = () => {
+        const rawState = storage.getItem(STORAGE_KEY);
+        if (rawState) {
+            try {
+                return JSON.parse(rawState);
+            } catch (error) {
+                console.warn('Saved state could not be parsed. Resetting.', error);
+            }
+        }
+        return fallbackState;
+    };
+
+    const persistState = (state) => {
+        fallbackState = state;
+        if (storage.isAvailable()) {
+            storage.setItem(STORAGE_KEY, JSON.stringify(state));
+        }
+    };
+
+    const clearPersistedState = () => {
+        fallbackState = null;
+        if (storage.isAvailable()) {
+            storage.removeItem(STORAGE_KEY);
+        }
     };
 
     // --- State Variables ---
@@ -1261,7 +1347,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     /**
-     * Saves the current application state to localStorage.
+     * Saves the current application state locally.
      */
     const saveState = () => {
         const state = {
@@ -1269,32 +1355,26 @@ document.addEventListener('DOMContentLoaded', () => {
             answers: answers,
             remainingTime: remainingTime
         };
-        try {
-            localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-        } catch (e) {
-            console.error("Error saving state to localStorage:", e);
-        }
+        persistState(state);
     };
 
     /**
-     * Loads state from localStorage on page load.
+     * Loads state from storage on page load.
      */
     const loadState = () => {
-        try {
-            const savedState = JSON.parse(localStorage.getItem(STORAGE_KEY));
-            if (savedState && savedState.studentID) {
-                studentIdInput.value = savedState.studentID;
-            }
-        } catch (e) {
-            console.error("Error loading state from localStorage:", e);
+        const savedState = getStoredState();
+        if (savedState && savedState.studentID) {
+            fallbackState = savedState;
+            studentIdInput.value = savedState.studentID;
         }
     };
 
     /**
      * Restores answers and timer from a saved state.
-     * @param {object} savedState - The state object from localStorage.
+     * @param {object} savedState - The state object from storage.
      */
     const restoreSession = (savedState) => {
+        fallbackState = savedState;
         answers = savedState.answers || {};
         remainingTime = savedState.remainingTime || TOTAL_EXAM_TIME;
         
@@ -1476,6 +1556,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (result.result === 'success') {
                 submissionStatus.textContent = 'Successfully submitted!';
                 submissionStatus.style.color = 'var(--primary-sage)';
+                clearPersistedState();
                 submissionConfirmed = true;
                 return;
             }
@@ -1540,20 +1621,15 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         studentID = enteredID;
 
-        try {
-            const savedState = JSON.parse(localStorage.getItem(STORAGE_KEY));
-            if (savedState && savedState.studentID === studentID) {
-                restoreSession(savedState);
-            } else {
-                answers = {};
-                remainingTime = TOTAL_EXAM_TIME;
-            }
-        } catch (e) {
-            console.error("Could not parse saved state, starting fresh.", e);
+        const savedState = getStoredState();
+        if (savedState && savedState.studentID === studentID) {
+            restoreSession(savedState);
+        } else {
+            clearPersistedState();
             answers = {};
             remainingTime = TOTAL_EXAM_TIME;
         }
-        
+
         saveState();
         showScreen('test');
         startTimer();

--- a/C1/C1.html
+++ b/C1/C1.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Level C1 End of Year Reading Exam</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;700;800&family=Questrial&display=swap" rel="stylesheet">
     <style>
     /* =====================================================================
        Organic Sage UI — Mobile-first, stable, and soothing
@@ -37,8 +34,8 @@
       --ink-muted: #5A6B52;
 
       /* Typography */
-      --font-display: 'Questrial', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, sans-serif;
-      --font-body: 'Nunito', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, sans-serif;
+      --font-display: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+      --font-body: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
 
       /* Fluid typography scale */
       --step--1: clamp(0.875rem, 0.84rem + 0.15vw, 0.95rem);
@@ -109,6 +106,7 @@
       font-size: var(--step-0);
       line-height: 1.6;
       color: var(--forest-shadow);
+      background-color: var(--warm-cream);
       background:
         radial-gradient(1200px 1200px at -10% -10%, #FFFFFF 0%, transparent 50%),
         radial-gradient(1200px 1000px at 110% 10%, #FFF8F0 0%, transparent 50%),
@@ -121,6 +119,21 @@
 
     @media (prefers-reduced-motion: no-preference) {
       html { scroll-behavior: smooth; }
+    }
+
+    @media (prefers-reduced-data: reduce) {
+      body {
+        background: var(--warm-cream);
+      }
+
+      #activity-container {
+        box-shadow: none;
+        background: #fff;
+      }
+
+      .activity-btn {
+        box-shadow: none;
+      }
     }
 
     /* Better text wrapping on small screens */
@@ -814,6 +827,12 @@
 </head>
 <body>
 
+    <noscript>
+        <div style="padding:1rem; background:#fff3cd; color:#664d03; text-align:center; font-weight:600;">
+            JavaScript is required to run this exam experience. Please enable it and reload the page.
+        </div>
+    </noscript>
+
     <div id="app-wrapper">
         <div id="activity-container">
 
@@ -1142,10 +1161,50 @@
             const STORAGE_KEY = `examState-${EXAM_LEVEL}`;
 
             const LEGACY_STORAGE_KEY = 'examState';
+            const storage = (() => {
+                let storageHealthy = true;
 
-            if (LEGACY_STORAGE_KEY !== STORAGE_KEY && localStorage.getItem(LEGACY_STORAGE_KEY)) {
+                const testAvailability = () => {
+                    try {
+                        const testKey = '__exam_storage_test__';
+                        window.localStorage.setItem(testKey, '1');
+                        window.localStorage.removeItem(testKey);
+                        return true;
+                    } catch (error) {
+                        console.warn('Local storage unavailable, falling back to memory only mode.', error);
+                        return false;
+                    }
+                };
 
-                localStorage.removeItem(LEGACY_STORAGE_KEY);
+                const isSupported = typeof window !== 'undefined' && 'localStorage' in window && testAvailability();
+
+                const safeRun = (operation) => {
+                    if (!isSupported || !storageHealthy) {
+                        return null;
+                    }
+
+                    try {
+                        return operation();
+                    } catch (error) {
+                        storageHealthy = false;
+                        console.warn('Local storage operation failed, disabling further writes.', error);
+                        return null;
+                    }
+                };
+
+                return {
+                    getItem: (key) => safeRun(() => window.localStorage.getItem(key)),
+                    setItem: (key, value) => safeRun(() => window.localStorage.setItem(key, value)),
+                    removeItem: (key) => safeRun(() => window.localStorage.removeItem(key)),
+                    isAvailable: () => isSupported && storageHealthy
+                };
+            })();
+
+            let fallbackState = null;
+
+            if (LEGACY_STORAGE_KEY !== STORAGE_KEY && storage.getItem(LEGACY_STORAGE_KEY)) {
+
+                storage.removeItem(LEGACY_STORAGE_KEY);
 
             }
 
@@ -1163,6 +1222,32 @@
                 '27': 'B', '28': 'C', '29': 'D', '30': 'B', '31': 'C',
                 '32': 'C', '33': 'F', '34': 'A', '35': 'B', '36': 'G',
                 '37': 'B', '38': 'A', '39': 'C', '40': 'B'
+            };
+
+            const getStoredState = () => {
+                const rawState = storage.getItem(STORAGE_KEY);
+                if (rawState) {
+                    try {
+                        return JSON.parse(rawState);
+                    } catch (error) {
+                        console.warn('Saved state could not be parsed. Resetting.', error);
+                    }
+                }
+                return fallbackState;
+            };
+
+            const persistState = (state) => {
+                fallbackState = state;
+                if (storage.isAvailable()) {
+                    storage.setItem(STORAGE_KEY, JSON.stringify(state));
+                }
+            };
+
+            const clearPersistedState = () => {
+                fallbackState = null;
+                if (storage.isAvailable()) {
+                    storage.removeItem(STORAGE_KEY);
+                }
             };
 
             let studentState = {
@@ -1227,26 +1312,16 @@
             };
 
             const saveState = () => {
-                try {
-                    localStorage.setItem(STORAGE_KEY, JSON.stringify(studentState));
-                } catch (e) {
-                    console.error("Failed to save state to localStorage:", e);
-                }
+                persistState(studentState);
             };
-            
+
             const loadState = () => {
-                try {
-                    const savedState = localStorage.getItem(STORAGE_KEY);
-                    if (savedState) {
-                        const parsedState = JSON.parse(savedState);
-                        // Only pre-fill ID. The rest is loaded when the user confirms the ID.
-                        if (parsedState.studentID) {
-                            studentIdInput.value = parsedState.studentID;
-                        }
+                const savedState = getStoredState();
+                if (savedState) {
+                    fallbackState = savedState;
+                    if (savedState.studentID) {
+                        studentIdInput.value = savedState.studentID;
                     }
-                } catch (e) {
-                    console.error("Failed to load state from localStorage:", e);
-                    localStorage.removeItem(STORAGE_KEY);
                 }
             };
 
@@ -1454,6 +1529,7 @@
                     if (result.result === 'success') {
                         submissionStatus.textContent = 'Successfully submitted!';
                         submissionStatus.style.color = '#2E7D32';
+                        clearPersistedState();
                         submissionConfirmed = true;
                         return;
                     }
@@ -1488,23 +1564,18 @@
                     return;
                 }
                 
-                const savedStateRaw = localStorage.getItem(STORAGE_KEY);
-                if (savedStateRaw) {
-                    const savedState = JSON.parse(savedStateRaw);
-                    if (savedState.studentID === enteredID) {
-                        // Resuming session
-                        studentState = savedState;
-                        if(studentState.remainingTime <= 0) studentState.remainingTime = TOTAL_TIME;
-                        populateAnswers();
-                    } else {
-                        // New student, clear old state
-                        studentState = { studentID: enteredID, answers: {}, remainingTime: TOTAL_TIME };
-                    }
+                const savedState = getStoredState();
+                if (savedState && savedState.studentID === enteredID) {
+                    // Resuming session
+                    studentState = savedState;
+                    if (studentState.remainingTime <= 0) studentState.remainingTime = TOTAL_TIME;
+                    populateAnswers();
                 } else {
-                    // No saved state, new session
-                    studentState.studentID = enteredID;
+                    // New student, clear old state
+                    clearPersistedState();
+                    studentState = { studentID: enteredID, answers: {}, remainingTime: TOTAL_TIME };
                 }
-                
+
                 saveState();
                 showScreen('test');
                 updateTimerDisplay();


### PR DESCRIPTION
## Summary
- Remove remote font dependencies and add reduced-data fallbacks plus inline noscript guidance across every exam page for low-bandwidth use
- Wrap localStorage access in safe helpers with an in-memory fallback so the exams continue working when storage is blocked
- Reset persisted answers on successful submission and when switching student IDs to avoid stale data between users

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d43936dd408326b1d5282b6876f0bd